### PR TITLE
Update faucet deps to 9.1 equivalent

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -13,11 +13,11 @@ repository cardano-haskell-packages
 -- See CONTRIBUTING for information about these, including some Nix commands
 -- you need to run if you change them
 index-state:
-  , hackage.haskell.org 2024-03-26T06:28:59Z
-  , cardano-haskell-packages 2024-05-06T13:38:48Z
+  , hackage.haskell.org 2024-09-04T12:37:50Z
+  , cardano-haskell-packages 2024-09-03T13:54:22Z
 
 packages:
-    cardano-faucet
+  cardano-faucet
 
 allow-newer:
   *:aeson,

--- a/cabal.project
+++ b/cabal.project
@@ -39,6 +39,11 @@ package snap-server
 package comonad
   flags: -test-doctests
 
+if os(windows)
+  -- Avoid `unknown symbol __cpu_model` when cross compilation runs TH code
+  package bitvec
+    flags: -simd
+
 -- IMPORTANT
 -- Do NOT add more source-repository-package stanzas here unless they are strictly
 -- temporary! Please read the section in CONTRIBUTING about updating dependencies.

--- a/cabal.project
+++ b/cabal.project
@@ -39,21 +39,6 @@ package snap-server
 package comonad
   flags: -test-doctests
 
--- Have to specify  '-Werror' for each package until this is released:
--- https://github.com/haskell/cabal/issues/3579
-
-package cardano-faucet
-  --ghc-options: -Werror
-
 -- IMPORTANT
 -- Do NOT add more source-repository-package stanzas here unless they are strictly
 -- temporary! Please read the section in CONTRIBUTING about updating dependencies.
-
--- Not published on CHaP
-source-repository-package
-    type: git
-    location: https://github.com/input-output-hk/cardano-addresses
-    tag: ed83fe7457da9adb53bb92acd0e79c321bd25646
-    --sha256: sha256-saxnZMeeZcASesw2Fgg9X0I8YFQ7p8jD25TMt782i2s=
-    subdir: command-line
-            core

--- a/cardano-faucet/cardano-faucet.cabal
+++ b/cardano-faucet/cardano-faucet.cabal
@@ -58,12 +58,12 @@ library
                         Cardano.Faucet.Web
                         Paths_cardano_faucet
 
-  build-depends:        aeson             >= 1.5.6.0
+  build-depends:        aeson              >= 1.5.6.0
                       , MissingH
                       , bytestring
                       , cardano-addresses ^>= 3.12.0
-                      , cardano-api ^>= 9.1.0.0
-                      , cardano-cli ^>= 9.2.1.0
+                      , cardano-api       ^>= 9.1.0.0
+                      , cardano-cli       ^>= 9.2.1.0
                       , cardano-prelude
                       , containers
                       , either

--- a/cardano-faucet/cardano-faucet.cabal
+++ b/cardano-faucet/cardano-faucet.cabal
@@ -1,7 +1,7 @@
 cabal-version: 3.0
 
 name:                   cardano-faucet
-version:                8.10
+version:                9.1
 description:            The Cardano command-line interface.
 author:                 IOHK
 maintainer:             operations@iohk.io
@@ -61,8 +61,8 @@ library
                       , MissingH
                       , bytestring
                       , cardano-addresses
-                      , cardano-api ^>= 8.45.2
-                      , cardano-cli ^>= 8.23
+                      , cardano-api ^>= 9.1.0.0
+                      , cardano-cli ^>= 9.2.1.0
                       , cardano-prelude
                       , containers
                       , either

--- a/cardano-faucet/cardano-faucet.cabal
+++ b/cardano-faucet/cardano-faucet.cabal
@@ -75,6 +75,7 @@ library
                       , ouroboros-consensus
                       , ouroboros-network-protocols
                       , parsec
+                      , protolude
                       , servant-client
                       , servant-server
                       , split

--- a/cardano-faucet/cardano-faucet.cabal
+++ b/cardano-faucet/cardano-faucet.cabal
@@ -28,6 +28,7 @@ common project-config
 
   ghc-options:          -Wall
                         -Wcompat
+                        -Werror
                         -Wincomplete-record-updates
                         -Wincomplete-uni-patterns
                         -Wpartial-fields
@@ -60,7 +61,7 @@ library
   build-depends:        aeson             >= 1.5.6.0
                       , MissingH
                       , bytestring
-                      , cardano-addresses
+                      , cardano-addresses ^>= 3.12.0
                       , cardano-api ^>= 9.1.0.0
                       , cardano-cli ^>= 9.2.1.0
                       , cardano-prelude

--- a/cardano-faucet/src/Cardano/Faucet.hs
+++ b/cardano-faucet/src/Cardano/Faucet.hs
@@ -46,6 +46,7 @@ import Ouroboros.Network.Protocol.LocalTxMonitor.Client qualified as CTxMon
 import Ouroboros.Network.Protocol.LocalTxSubmission.Client qualified as Net.Tx
 import Paths_cardano_faucet (getDataFileName)
 import Prelude qualified
+import Protolude (print, readFile)
 import Servant
 import System.Environment (lookupEnv)
 import System.IO (hSetBuffering, BufferMode(LineBuffering))

--- a/cardano-faucet/src/Cardano/Faucet/Misc.hs
+++ b/cardano-faucet/src/Cardano/Faucet/Misc.hs
@@ -2,9 +2,19 @@
 
 module Cardano.Faucet.Misc where
 
-import Cardano.Api (ConsensusModeParams(CardanoModeParams), EpochSlots(EpochSlots), AddressAny, parseAddressAny, TxOutValue(..), AssetId(AdaAssetId), Quantity, fromLedgerValue, valueToList)
-import qualified Cardano.Api.Ledger as L
-import Cardano.Api.Shelley (selectLovelace, AssetId(AssetId))
+import Cardano.Api (
+  AddressAny,
+  AssetId (AdaAssetId),
+  ConsensusModeParams (CardanoModeParams),
+  EpochSlots (EpochSlots),
+  Quantity,
+  TxOutValue (..),
+  fromLedgerValue,
+  parseAddressAny,
+  valueToList,
+ )
+import Cardano.Api.Ledger qualified as L
+import Cardano.Api.Shelley (AssetId (AssetId), selectLovelace)
 import Cardano.Faucet.Types
 import Cardano.Prelude
 import Control.Monad.Trans.Except.Extra (left)

--- a/cardano-faucet/src/Cardano/Faucet/Misc.hs
+++ b/cardano-faucet/src/Cardano/Faucet/Misc.hs
@@ -46,7 +46,7 @@ faucetValueToLovelace (FaucetValueManyTokens ll) = ll
 
 parseAddress :: Text -> ExceptT FaucetWebError IO AddressAny
 parseAddress addr = case parse (parseAddressAny <* eof) "" (T.unpack addr) of
-  Right a -> return $ a
+  Right a -> return a
   Left e -> left $ FaucetWebErrorInvalidAddress addr (show e)
 
 defaultCModeParams :: ConsensusModeParams

--- a/cardano-faucet/src/Cardano/Faucet/TxUtils.hs
+++ b/cardano-faucet/src/Cardano/Faucet/TxUtils.hs
@@ -1,7 +1,3 @@
-{-# LANGUAGE ImportQualifiedPost #-}
-{-# LANGUAGE TypeApplications #-}
-{-# LANGUAGE OverloadedStrings #-}
-
 module Cardano.Faucet.TxUtils where
 
 import Cardano.Api (ShelleyBasedEra, TxIn, TxOut(TxOut), CtxUTxO, TxBody, TxBodyContent(TxBodyContent), Witness(KeyWitness), KeyWitnessInCtx(KeyWitnessForSpending), TxInsCollateral(TxInsCollateralNone), TxInsReference(TxInsReferenceNone), TxTotalCollateral(TxTotalCollateralNone), TxReturnCollateral(TxReturnCollateralNone), TxMetadataInEra(TxMetadataNone), TxAuxScripts(TxAuxScriptsNone), TxExtraKeyWitnesses(TxExtraKeyWitnessesNone), TxWithdrawals(TxWithdrawalsNone), TxCertificates, BuildTxWith(BuildTxWith), TxUpdateProposal(TxUpdateProposalNone), TxMintValue(..), TxScriptValidity(TxScriptValidityNone), defaultTxValidityUpperBound, docToText, Tx, makeShelleyKeyWitness, makeSignedTransaction, TxId, getTxId, BuildTx, ShelleyWitnessSigningKey, AddressAny, TxValidityLowerBound (TxValidityNoLowerBound))
@@ -18,7 +14,7 @@ import Cardano.CLI.Types.Errors.TxCmdError
 
 getMintedValue :: TxMintValue BuildTx era -> Value
 getMintedValue (TxMintValue _ val _) = val
-getMintedValue (TxMintNone) = mempty
+getMintedValue TxMintNone = mempty
 
 newtype Fee = Fee L.Coin
 
@@ -42,7 +38,7 @@ txBuild sbe (txin, txout) addressOrOutputs certs minting (Fee fixedFee) = do
     mintedValue = getMintedValue minting
     -- TODO, add minted tokens
     changeValue :: Value
-    changeValue = (lovelaceToValue change) <> mintedValue
+    changeValue = lovelaceToValue change <> mintedValue
 
     getTxOuts :: Either AddressAny [TxOutAnyEra] -> [TxOutAnyEra]
     getTxOuts (Left addr) = [ TxOutAnyEra addr changeValue TxOutDatumByNone ReferenceScriptAnyEraNone ]

--- a/cardano-faucet/src/Cardano/Faucet/TxUtils.hs
+++ b/cardano-faucet/src/Cardano/Faucet/TxUtils.hs
@@ -69,6 +69,8 @@ txBuild sbe (txin, txout) addressOrOutputs certs minting (Fee fixedFee) = do
     <*> pure TxScriptValidityNone
     <*> pure Nothing
     <*> pure Nothing
+    <*> pure Nothing
+    <*> pure Nothing
 
   case createAndValidateTransactionBody sbe txBodyContent of
     Left err -> left $ FaucetWebErrorTodo $ show err

--- a/cardano-faucet/src/Cardano/Faucet/TxUtils.hs
+++ b/cardano-faucet/src/Cardano/Faucet/TxUtils.hs
@@ -1,16 +1,49 @@
 module Cardano.Faucet.TxUtils where
 
-import Cardano.Api (ShelleyBasedEra, TxIn, TxOut(TxOut), CtxUTxO, TxBody, TxBodyContent(TxBodyContent), Witness(KeyWitness), KeyWitnessInCtx(KeyWitnessForSpending), TxInsCollateral(TxInsCollateralNone), TxInsReference(TxInsReferenceNone), TxTotalCollateral(TxTotalCollateralNone), TxReturnCollateral(TxReturnCollateralNone), TxMetadataInEra(TxMetadataNone), TxAuxScripts(TxAuxScriptsNone), TxExtraKeyWitnesses(TxExtraKeyWitnessesNone), TxWithdrawals(TxWithdrawalsNone), TxCertificates, BuildTxWith(BuildTxWith), TxUpdateProposal(TxUpdateProposalNone), TxMintValue(..), TxScriptValidity(TxScriptValidityNone), defaultTxValidityUpperBound, docToText, Tx, makeShelleyKeyWitness, makeSignedTransaction, TxId, getTxId, BuildTx, ShelleyWitnessSigningKey, AddressAny, TxValidityLowerBound (TxValidityNoLowerBound))
+import Cardano.Api (
+  AddressAny,
+  BuildTx,
+  BuildTxWith (BuildTxWith),
+  CtxUTxO,
+  KeyWitnessInCtx (KeyWitnessForSpending),
+  ShelleyBasedEra,
+  ShelleyWitnessSigningKey,
+  Tx,
+  TxAuxScripts (TxAuxScriptsNone),
+  TxBody,
+  TxBodyContent (TxBodyContent),
+  TxCertificates,
+  TxExtraKeyWitnesses (TxExtraKeyWitnessesNone),
+  TxId,
+  TxIn,
+  TxInsCollateral (TxInsCollateralNone),
+  TxInsReference (TxInsReferenceNone),
+  TxMetadataInEra (TxMetadataNone),
+  TxMintValue (..),
+  TxOut (TxOut),
+  TxReturnCollateral (TxReturnCollateralNone),
+  TxScriptValidity (TxScriptValidityNone),
+  TxTotalCollateral (TxTotalCollateralNone),
+  TxUpdateProposal (TxUpdateProposalNone),
+  TxValidityLowerBound (TxValidityNoLowerBound),
+  TxWithdrawals (TxWithdrawalsNone),
+  Witness (KeyWitness),
+  defaultTxValidityUpperBound,
+  docToText,
+  getTxId,
+  makeShelleyKeyWitness,
+  makeSignedTransaction,
+ )
 import qualified Cardano.Api.Ledger as L
-import Cardano.Api.Shelley (lovelaceToValue, Value, createAndValidateTransactionBody)
-import Cardano.Faucet.Misc (getValue, faucetValueToLovelace)
-import Cardano.Faucet.Types (FaucetWebError(..), FaucetValue)
+import Cardano.Api.Shelley (Value, createAndValidateTransactionBody, lovelaceToValue)
+import Cardano.CLI.EraBased.Run.Transaction
+import Cardano.CLI.Types.Common
+import Cardano.CLI.Types.Errors.TxCmdError
+import Cardano.Faucet.Misc (faucetValueToLovelace, getValue)
+import Cardano.Faucet.Types (FaucetValue, FaucetWebError (..))
 import Cardano.Faucet.Utils
 import Cardano.Prelude hiding ((%))
 import Control.Monad.Trans.Except.Extra (left)
-import Cardano.CLI.Types.Common
-import Cardano.CLI.EraBased.Run.Transaction
-import Cardano.CLI.Types.Errors.TxCmdError
 
 getMintedValue :: TxMintValue BuildTx era -> Value
 getMintedValue (TxMintValue _ val _) = val
@@ -18,17 +51,18 @@ getMintedValue TxMintNone = mempty
 
 newtype Fee = Fee L.Coin
 
-txBuild :: ()
-  => ShelleyBasedEra era
-  -> (TxIn, TxOut CtxUTxO era)
-  -> Either AddressAny [TxOutAnyEra]
-  -> TxCertificates BuildTx era
-  -> TxMintValue BuildTx era
-  -> Fee
-  -> ExceptT FaucetWebError IO (TxBody era)
+txBuild ::
+  () =>
+  ShelleyBasedEra era ->
+  (TxIn, TxOut CtxUTxO era) ->
+  Either AddressAny [TxOutAnyEra] ->
+  TxCertificates BuildTx era ->
+  TxMintValue BuildTx era ->
+  Fee ->
+  ExceptT FaucetWebError IO (TxBody era)
 txBuild sbe (txin, txout) addressOrOutputs certs minting (Fee fixedFee) = do
   let
-    --localNodeConnInfo = LocalNodeConnectInfo cModeParams networkId sockPath
+    -- localNodeConnInfo = LocalNodeConnectInfo cModeParams networkId sockPath
     unwrap :: TxOut ctx1 era1 -> FaucetValue
     unwrap (TxOut _ val _ _) = getValue val
     value :: L.Coin
@@ -41,98 +75,105 @@ txBuild sbe (txin, txout) addressOrOutputs certs minting (Fee fixedFee) = do
     changeValue = lovelaceToValue change <> mintedValue
 
     getTxOuts :: Either AddressAny [TxOutAnyEra] -> [TxOutAnyEra]
-    getTxOuts (Left addr) = [ TxOutAnyEra addr changeValue TxOutDatumByNone ReferenceScriptAnyEraNone ]
+    getTxOuts (Left addr) = [TxOutAnyEra addr changeValue TxOutDatumByNone ReferenceScriptAnyEraNone]
     getTxOuts (Right outs) = outs
 
-  txBodyContent <- TxBodyContent
-    <$> pure [(txin, BuildTxWith $ KeyWitness KeyWitnessForSpending)]
-    <*> pure TxInsCollateralNone
-    <*> pure TxInsReferenceNone
-    <*> mapM (\x -> withExceptT (FaucetWebErrorTodo . docToText . renderTxCmdError) $ toTxOutInAnyEra sbe x) (getTxOuts addressOrOutputs)
-    <*> pure TxTotalCollateralNone
-    <*> pure TxReturnCollateralNone
-    <*> validateTxFee sbe (Just fixedFee)
-    <*> pure TxValidityNoLowerBound
-    <*> pure (defaultTxValidityUpperBound sbe)
-    <*> pure TxMetadataNone
-    <*> pure TxAuxScriptsNone
-    <*> pure TxExtraKeyWitnessesNone
-    <*> pure (BuildTxWith Nothing)
-    <*> pure TxWithdrawalsNone
-    <*> pure certs
-    <*> pure TxUpdateProposalNone
-    <*> pure minting
-    <*> pure TxScriptValidityNone
-    <*> pure Nothing
-    <*> pure Nothing
-    <*> pure Nothing
-    <*> pure Nothing
+  txBodyContent <-
+    TxBodyContent
+      <$> pure [(txin, BuildTxWith $ KeyWitness KeyWitnessForSpending)]
+      <*> pure TxInsCollateralNone
+      <*> pure TxInsReferenceNone
+      <*> mapM
+        (\x -> withExceptT (FaucetWebErrorTodo . docToText . renderTxCmdError) $ toTxOutInAnyEra sbe x)
+        (getTxOuts addressOrOutputs)
+      <*> pure TxTotalCollateralNone
+      <*> pure TxReturnCollateralNone
+      <*> validateTxFee sbe (Just fixedFee)
+      <*> pure TxValidityNoLowerBound
+      <*> pure (defaultTxValidityUpperBound sbe)
+      <*> pure TxMetadataNone
+      <*> pure TxAuxScriptsNone
+      <*> pure TxExtraKeyWitnessesNone
+      <*> pure (BuildTxWith Nothing)
+      <*> pure TxWithdrawalsNone
+      <*> pure certs
+      <*> pure TxUpdateProposalNone
+      <*> pure minting
+      <*> pure TxScriptValidityNone
+      <*> pure Nothing
+      <*> pure Nothing
+      <*> pure Nothing
+      <*> pure Nothing
 
   case createAndValidateTransactionBody sbe txBodyContent of
     Left err -> left $ FaucetWebErrorTodo $ show err
     Right txbody -> pure txbody
-  {-
-   -- keep this code for now, as an example of how to use the cardano api in a monad
-  eInMode <- case toEraInMode era CardanoMode of
-    Just result -> return result
-    Nothing -> left (FaucetWebErrorConsensusModeMismatchTxBalance (show $ AnyConsensusMode CardanoMode) (AnyCardanoEra era))
 
-  let
-    utxo = UTxO $ Map.fromList [ (txin, txout) ]
+{-
+ -- keep this code for now, as an example of how to use the cardano api in a monad
+eInMode <- case toEraInMode era CardanoMode of
+  Just result -> return result
+  Nothing -> left (FaucetWebErrorConsensusModeMismatchTxBalance (show $ AnyConsensusMode CardanoMode) (AnyCardanoEra era))
 
-  (pparams, eraHistory, systemStart, stakePools) <-
-    newExceptT . fmap (join . first (FaucetWebErrorAcquireFailure . show)) $
-      executeLocalStateQueryExpr localNodeConnInfo Nothing $ \_ntcVersion -> runExceptT $ do
-        --UTxO utxo <- firstExceptT (_ . ShelleyTxCmdTxSubmitErrorEraMismatch) . newExceptT . queryExpr
-        --  $ QueryInEra eInMode $ QueryInShelleyBasedEra sbe
-        --  $ QueryUTxO (QueryUTxOByTxIn (Set.singleton txin))
+let
+  utxo = UTxO $ Map.fromList [ (txin, txout) ]
 
-        --when (null utxo || not (txin `L.elem` Map.keys utxo)) $ do
-          -- txout for txin does not exist
-        --  left $ ShelleyTxCmdTxInsDoNotExist [txin]
+(pparams, eraHistory, systemStart, stakePools) <-
+  newExceptT . fmap (join . first (FaucetWebErrorAcquireFailure . show)) $
+    executeLocalStateQueryExpr localNodeConnInfo Nothing $ \_ntcVersion -> runExceptT $ do
+      --UTxO utxo <- firstExceptT (_ . ShelleyTxCmdTxSubmitErrorEraMismatch) . newExceptT . queryExpr
+      --  $ QueryInEra eInMode $ QueryInShelleyBasedEra sbe
+      --  $ QueryUTxO (QueryUTxOByTxIn (Set.singleton txin))
 
-        pparams <- firstExceptT (FaucetWebErrorEraMismatch . show) . newExceptT . queryExpr
-          $ QueryInEra eInMode $ QueryInShelleyBasedEra sbe QueryProtocolParameters
+      --when (null utxo || not (txin `L.elem` Map.keys utxo)) $ do
+        -- txout for txin does not exist
+      --  left $ ShelleyTxCmdTxInsDoNotExist [txin]
 
-        eraHistory <- lift . queryExpr $ QueryEraHistory CardanoModeIsMultiEra
+      pparams <- firstExceptT (FaucetWebErrorEraMismatch . show) . newExceptT . queryExpr
+        $ QueryInEra eInMode $ QueryInShelleyBasedEra sbe QueryProtocolParameters
 
-        systemStart <- lift $ queryExpr QuerySystemStart
+      eraHistory <- lift . queryExpr $ QueryEraHistory CardanoModeIsMultiEra
 
-        stakePools <- firstExceptT (FaucetWebErrorEraMismatch . show) . ExceptT $
-          queryExpr . QueryInEra eInMode . QueryInShelleyBasedEra sbe $ QueryStakePools
+      systemStart <- lift $ queryExpr QuerySystemStart
 
-        return (pparams, eraHistory, systemStart, stakePools)
+      stakePools <- firstExceptT (FaucetWebErrorEraMismatch . show) . ExceptT $
+        queryExpr . QueryInEra eInMode . QueryInShelleyBasedEra sbe $ QueryStakePools
 
-  cAddr <- pure $ case anyAddressInEra era changeAddr of
-    Just addr -> addr
-    Nothing -> Prelude.error "txBuild: Byron address used: "
+      return (pparams, eraHistory, systemStart, stakePools)
 
-  (BalancedTxBody balancedTxBody _ _fee) <- firstExceptT (FaucetWebErrorAutoBalance . T.pack . displayError) . hoistEither $
-    makeTransactionBodyAutoBalance eInMode systemStart eraHistory pparams stakePools utxo txBodyContent cAddr Nothing
+cAddr <- pure $ case anyAddressInEra era changeAddr of
+  Just addr -> addr
+  Nothing -> Prelude.error "txBuild: Byron address used: "
 
-  return balancedTxBody
-  -}
+(BalancedTxBody balancedTxBody _ _fee) <- firstExceptT (FaucetWebErrorAutoBalance . T.pack . displayError) . hoistEither $
+  makeTransactionBodyAutoBalance eInMode systemStart eraHistory pparams stakePools utxo txBodyContent cAddr Nothing
 
-txSign :: ()
-  => ShelleyBasedEra era
-  -> TxBody era
-  -> [ShelleyWitnessSigningKey]
-  -> Tx era
+return balancedTxBody
+-}
+
+txSign ::
+  () =>
+  ShelleyBasedEra era ->
+  TxBody era ->
+  [ShelleyWitnessSigningKey] ->
+  Tx era
 txSign era txBody sks = tx
-  --let (sksByron, sksShelley) = partitionSomeWitnesses $ map categoriseSomeWitness sks
   where
+    -- let (sksByron, sksShelley) = partitionSomeWitnesses $ map categoriseSomeWitness sks
+
     shelleyKeyWitnesses = map (makeShelleyKeyWitness era txBody) sks
     tx = makeSignedTransaction shelleyKeyWitnesses txBody
 
-makeAndSignTx :: ()
-  => ShelleyBasedEra era
-  -> (TxIn, TxOut CtxUTxO era)
-  -> Either AddressAny [TxOutAnyEra]
-  -> [ShelleyWitnessSigningKey]
-  -> TxCertificates BuildTx era
-  -> TxMintValue BuildTx era
-  -> Fee
-  -> ExceptT FaucetWebError IO (Tx era, TxId)
+makeAndSignTx ::
+  () =>
+  ShelleyBasedEra era ->
+  (TxIn, TxOut CtxUTxO era) ->
+  Either AddressAny [TxOutAnyEra] ->
+  [ShelleyWitnessSigningKey] ->
+  TxCertificates BuildTx era ->
+  TxMintValue BuildTx era ->
+  Fee ->
+  ExceptT FaucetWebError IO (Tx era, TxId)
 makeAndSignTx sbe txinout addressOrOutputs skeys certs minting fee = do
   -- instead of having to specify an output that is exactly equal to input-fees
   -- i specify no outputs, and set the change addr to the end-user

--- a/cardano-faucet/src/Cardano/Faucet/Types.hs
+++ b/cardano-faucet/src/Cardano/Faucet/Types.hs
@@ -2,7 +2,6 @@
 {-# LANGUAGE ImportQualifiedPost #-}
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE TypeApplications #-}
-{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE RecordWildCards #-}
 
@@ -47,7 +46,7 @@ instance FromHttpApiData CaptchaToken where
 newtype ForwardedFor = ForwardedFor [IPv4] deriving (Eq, Show)
 
 parseIpList :: Prelude.String -> ForwardedFor
-parseIpList input = ForwardedFor $ reverse $ map (Prelude.read) (splitOn "," input)
+parseIpList input = ForwardedFor $ reverse $ map Prelude.read (splitOn "," input)
 
 instance FromHttpApiData ForwardedFor where
   parseHeader = Right . parseIpList . BSC.unpack
@@ -65,13 +64,13 @@ data FaucetError = FaucetErrorSocketNotFound
   deriving Generic
 
 renderFaucetError :: FaucetError -> Text
-renderFaucetError (FaucetErrorSocketNotFound) = "socket not found"
+renderFaucetError FaucetErrorSocketNotFound = "socket not found"
 renderFaucetError (FaucetErrorLoadingKey err) = show err
 renderFaucetError (FaucetErrorParsingConfig err) = show err
 renderFaucetError FaucetErrorConfigFileNotSet = "$CONFIG_FILE not set"
 renderFaucetError (FaucetErrorBadMnemonic msg) = "bad mnemonic " <> msg
 renderFaucetError FaucetErrorBadIdx = "bad index"
-renderFaucetError (FaucetErrorAddr err) = docToText $ renderAddressCmdError $ err
+renderFaucetError (FaucetErrorAddr err) = docToText $ renderAddressCmdError err
 renderFaucetError (FaucetErrorTodo2 err) = show err
 
 -- errors that can be sent to the user

--- a/cardano-faucet/src/Cardano/Faucet/Types.hs
+++ b/cardano-faucet/src/Cardano/Faucet/Types.hs
@@ -8,8 +8,6 @@
 
 module Cardano.Faucet.Types (FaucetValue(..), ApiKeyValue(..), FaucetToken(..), FaucetWebError(..), UtxoStats(..), CaptchaToken, ForwardedFor(..), SendMoneyReply(..), DelegationReply(..), SiteVerifyReply(..), SiteVerifyRequest(..), SecretKey, FaucetState(..), RateLimitResult(..), ApiKey(..), RateLimitAddress(..), FaucetConfigFile(..), SiteKey(..), SendMoneySent(..), rootKeyToPolicyKey, FaucetError(..), StakeKeyIntermediateState(..), StakeKeyState(..), accountKeyToStakeKey, parseConfig, mnemonicToRootKey, rootKeytoAcctKey, accountKeyToPaymentKey, renderFaucetError, test) where
 
-import Prelude (fail)
-
 import Cardano.Address.Derivation (Depth(RootK, AccountK, PaymentK, PolicyK), XPrv, genMasterKeyFromMnemonic, indexFromWord32, deriveAccountPrivateKey, deriveAddressPrivateKey, Index, DerivationType(Hardened, Soft))
 import Cardano.Address.Style.Shelley (Shelley, Role(UTxOExternal, Stake), derivePolicyPrivateKey)
 import Cardano.Api (AnyCardanoEra, InputDecodeError, TxIn, TxOut, CtxUTxO, TxInMode,  TxId, FileError, AddressAny, AssetId(AssetId, AdaAssetId), Quantity, SigningKey, PaymentExtendedKey, VerificationKey, HashableScriptData, docToText)
@@ -31,7 +29,8 @@ import Data.List.Split (splitOn)
 import Data.Map.Strict qualified as Map
 import Data.Text qualified as T
 import Data.Time.Clock (UTCTime, NominalDiffTime)
-import Prelude (String, error, read)
+import Prelude (fail, String, error, read)
+import Protolude (print)
 import Servant (FromHttpApiData(parseHeader, parseQueryParam, parseUrlPiece))
 import Web.Internal.FormUrlEncoded (ToForm(toForm), fromEntriesByKey)
 

--- a/cardano-faucet/src/Cardano/Faucet/Utils.hs
+++ b/cardano-faucet/src/Cardano/Faucet/Utils.hs
@@ -1,24 +1,38 @@
 {-# LANGUAGE DataKinds #-}
-{-# LANGUAGE ImportQualifiedPost #-}
-{-# LANGUAGE NamedFieldPuns #-}
-{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE GADTs #-}
+{-# LANGUAGE ImportQualifiedPost #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE NamedFieldPuns #-}
 
 module Cardano.Faucet.Utils where
 
-import Cardano.Api (toCardanoEra, TxIn, TxOut(TxOut), CtxUTxO, TxFee (..), defaultTxValidityUpperBound, TxValidityLowerBound(TxValidityNoLowerBound), TxValidityUpperBound, ShelleyBasedEra, AnyCardanoEra (..), shelleyBasedEraConstraints, Tx, CardanoEra (..))
-import qualified Cardano.Api.Ledger as L
-import Cardano.Api.Shelley (ShelleyBasedEra(..))
-import qualified Cardano.CLI.Json.Friendly as CLI
-import qualified Cardano.CLI.Types.MonadWarning as CLI
+import Cardano.Api (
+  AnyCardanoEra (..),
+  CardanoEra (..),
+  CtxUTxO,
+  ShelleyBasedEra,
+  Tx,
+  TxFee (..),
+  TxIn,
+  TxOut (TxOut),
+  TxValidityLowerBound (TxValidityNoLowerBound),
+  TxValidityUpperBound,
+  defaultTxValidityUpperBound,
+  shelleyBasedEraConstraints,
+  toCardanoEra,
+ )
+import Cardano.Api.Ledger qualified as L
+import Cardano.Api.Shelley (ShelleyBasedEra (..))
+import Cardano.CLI.Json.Friendly qualified as CLI
+import Cardano.CLI.Types.MonadWarning qualified as CLI
 import Cardano.Faucet.Misc
 import Cardano.Faucet.Types
 import Cardano.Prelude hiding ((%))
-import Control.Concurrent.STM (TMVar, takeTMVar, putTMVar)
+import Control.Concurrent.STM (TMVar, putTMVar, takeTMVar)
 import Control.Monad.Trans.Except.Extra (left)
-import qualified Data.ByteString as BS
+import Data.ByteString qualified as BS
 import Data.Map.Strict qualified as Map
-import qualified Prelude
+import Prelude qualified
 
 computeUtxoStats :: Map TxIn (TxOut CtxUTxO era) -> UtxoStats
 computeUtxoStats utxo = do
@@ -26,20 +40,22 @@ computeUtxoStats utxo = do
     convertValue :: TxOut ctx era -> FaucetValue
     -- TODO, also report tokens in this list/type
     convertValue (TxOut _ value _ _) = getValue value
-    --folder :: UtxoStats -> FaucetValue -> UtxoStats
-    --folder (UtxoStats m) v = UtxoStats $ Map.insert v ((fromMaybe 0 $ Map.lookup v m) + 1) m
+  -- folder :: UtxoStats -> FaucetValue -> UtxoStats
+  -- folder (UtxoStats m) v = UtxoStats $ Map.insert v ((fromMaybe 0 $ Map.lookup v m) + 1) m
   UtxoStats $ Map.fromList $ countLength $ sort $ map convertValue $ Map.elems utxo
-  --foldl' folder (UtxoStats mempty) $ concat $ map convertValue $ Map.elems utxo
+
+-- foldl' folder (UtxoStats mempty) $ concat $ map convertValue $ Map.elems utxo
 
 countDuplicates :: Ord a => [a] -> [(a, Int)]
 countDuplicates = map fn . group . sort
   where
-    fn (x:xs) = (x, 1 + length xs)
+    fn (x : xs) = (x, 1 + length xs)
     fn [] = Prelude.error "not possible"
 
 -- from https://hackage.haskell.org/package/polysemy-plugin-0.4.3.1/docs/Polysemy-Plugin-Fundep-Utils.html#v:countLength
+
 -- | Count the number of times 'a' is present in the list.
-countLength ::  Eq a => [a] -> [(a, Int)]
+countLength :: Eq a => [a] -> [(a, Int)]
 countLength as =
   let grouped = group as
    in zipWith (curry $ bimap Prelude.head Prelude.length) grouped grouped
@@ -62,42 +78,48 @@ takeOneUtxo utxoTMVar value = do
       putTMVar utxoTMVar utxo
       pure Nothing
 
-findUtxoOfSize :: TMVar (Map TxIn (TxOut CtxUTxO era)) -> FaucetValue -> STM (TxIn, TxOut CtxUTxO era)
+findUtxoOfSize ::
+  TMVar (Map TxIn (TxOut CtxUTxO era)) -> FaucetValue -> STM (TxIn, TxOut CtxUTxO era)
 findUtxoOfSize utxoTMVar value = do
   -- TODO, include fee
-  mTxinout <- {- liftIO $ atomically $ -} takeOneUtxo utxoTMVar value
+  mTxinout {- liftIO $ atomically $ -} <- takeOneUtxo utxoTMVar value
   case mTxinout of
     Just txinout -> pure txinout
     Nothing -> throwSTM $ FaucetWebErrorUtxoNotFound value
 
-validateTxFee :: ()
-  => ShelleyBasedEra era
-  -> Maybe L.Coin
-  -> ExceptT FaucetWebError IO (TxFee era)
+validateTxFee ::
+  () =>
+  ShelleyBasedEra era ->
+  Maybe L.Coin ->
+  ExceptT FaucetWebError IO (TxFee era)
 validateTxFee sbe mfee =
   case mfee of
     Nothing -> txFeatureMismatch sbe -- Fees are explicit since Shelley
     Just fee -> return $ TxFeeExplicit sbe fee
 
-txFeatureMismatch :: ()
-  => ShelleyBasedEra era
-  -> ExceptT FaucetWebError IO a
+txFeatureMismatch ::
+  () =>
+  ShelleyBasedEra era ->
+  ExceptT FaucetWebError IO a
 txFeatureMismatch sbe =
-   left $ FaucetWebErrorFeatureMismatch $
-     shelleyBasedEraConstraints sbe AnyCardanoEra $ toCardanoEra sbe
+  left
+    $ FaucetWebErrorFeatureMismatch
+    $ shelleyBasedEraConstraints sbe AnyCardanoEra
+    $ toCardanoEra sbe
 
 noBoundsIfSupported ::
-     ShelleyBasedEra era
-  -> (TxValidityLowerBound era, TxValidityUpperBound era)
+  ShelleyBasedEra era ->
+  (TxValidityLowerBound era, TxValidityUpperBound era)
 noBoundsIfSupported sbe = (TxValidityNoLowerBound, defaultTxValidityUpperBound sbe)
 
-prettyFriendlyTx :: ()
-  => ShelleyBasedEra era
-  -> Tx era
-  -> BS.ByteString
+prettyFriendlyTx ::
+  () =>
+  ShelleyBasedEra era ->
+  Tx era ->
+  BS.ByteString
 prettyFriendlyTx sbe tx =
-   CLI.friendlyBS CLI.FriendlyJson prettyTxAeson
-   where
+  CLI.friendlyBS CLI.FriendlyJson prettyTxAeson
+  where
     era = toCardanoEra sbe
     prettyTxAeson = fst $ runState (CLI.runWarningStateT $ CLI.friendlyTxImpl era tx) []
 
@@ -105,10 +127,10 @@ prettyFriendlyTx sbe tx =
 -- or returns an error message if the era is not Shelley based.
 cardanoEraToShelleyBasedEra :: CardanoEra era -> Either Text (ShelleyBasedEra era)
 cardanoEraToShelleyBasedEra = \case
-  ByronEra   -> Left "Byron is not a Shelley based era"
+  ByronEra -> Left "Byron is not a Shelley based era"
   ShelleyEra -> Right ShelleyBasedEraShelley
   AllegraEra -> Right ShelleyBasedEraAllegra
-  MaryEra    -> Right ShelleyBasedEraMary
-  AlonzoEra  -> Right ShelleyBasedEraAlonzo
+  MaryEra -> Right ShelleyBasedEraMary
+  AlonzoEra -> Right ShelleyBasedEraAlonzo
   BabbageEra -> Right ShelleyBasedEraBabbage
-  ConwayEra  -> Right ShelleyBasedEraConway
+  ConwayEra -> Right ShelleyBasedEraConway

--- a/cardano-faucet/src/Cardano/Faucet/Utils.hs
+++ b/cardano-faucet/src/Cardano/Faucet/Utils.hs
@@ -1,7 +1,5 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE ImportQualifiedPost #-}
-{-# LANGUAGE TypeOperators #-}
-{-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE GADTs #-}

--- a/cardano-faucet/src/Cardano/Faucet/Utils.hs
+++ b/cardano-faucet/src/Cardano/Faucet/Utils.hs
@@ -8,7 +8,7 @@
 
 module Cardano.Faucet.Utils where
 
-import Cardano.Api (TxIn, TxOut(TxOut), CtxUTxO, TxFee (..), defaultTxValidityUpperBound, TxValidityLowerBound(TxValidityNoLowerBound), TxValidityUpperBound, ShelleyBasedEra, shelleyBasedToCardanoEra, AnyCardanoEra (..), shelleyBasedEraConstraints, Tx, CardanoEra (..))
+import Cardano.Api (toCardanoEra, TxIn, TxOut(TxOut), CtxUTxO, TxFee (..), defaultTxValidityUpperBound, TxValidityLowerBound(TxValidityNoLowerBound), TxValidityUpperBound, ShelleyBasedEra, AnyCardanoEra (..), shelleyBasedEraConstraints, Tx, CardanoEra (..))
 import qualified Cardano.Api.Ledger as L
 import Cardano.Api.Shelley (ShelleyBasedEra(..))
 import qualified Cardano.CLI.Json.Friendly as CLI
@@ -86,7 +86,7 @@ txFeatureMismatch :: ()
   -> ExceptT FaucetWebError IO a
 txFeatureMismatch sbe =
    left $ FaucetWebErrorFeatureMismatch $
-     shelleyBasedEraConstraints sbe AnyCardanoEra $ shelleyBasedToCardanoEra sbe
+     shelleyBasedEraConstraints sbe AnyCardanoEra $ toCardanoEra sbe
 
 noBoundsIfSupported ::
      ShelleyBasedEra era
@@ -100,7 +100,7 @@ prettyFriendlyTx :: ()
 prettyFriendlyTx sbe tx =
    CLI.friendlyBS CLI.FriendlyJson prettyTxAeson
    where
-    era = shelleyBasedToCardanoEra sbe
+    era = toCardanoEra sbe
     prettyTxAeson = fst $ runState (CLI.runWarningStateT $ CLI.friendlyTxImpl era tx) []
 
 -- | @cardanoEraToShelleyBasedEra@ converts a 'CardanoEra' to a 'ShelleyBasedEra'

--- a/cardano-faucet/src/Cardano/Faucet/Web.hs
+++ b/cardano-faucet/src/Cardano/Faucet/Web.hs
@@ -39,6 +39,7 @@ import Network.HTTP.Client.TLS (newTlsManagerWith, tlsManagerSettings)
 import Network.HTTP.Media.MediaType ((//), (/:))
 import Network.Socket (SockAddr(SockAddrInet))
 import Prelude qualified (id)
+import Protolude (print)
 import Servant
 import Servant.Client (ClientM, ClientError, client, runClientM, mkClientEnv, BaseUrl(BaseUrl), Scheme(Https))
 import Cardano.Address.Style.Shelley (Shelley, getKey)

--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "CHaP": {
       "flake": false,
       "locked": {
-        "lastModified": 1715003668,
-        "narHash": "sha256-glaw6l5R7TTHxC1rfHs6IayoAwrtGuN7WBKZfb1V7Eg=",
+        "lastModified": 1725372492,
+        "narHash": "sha256-eQwfZIEHH5qHZQHXujgjj35dVAqSZa6EbTRWeppn1ME=",
         "owner": "input-output-hk",
         "repo": "cardano-haskell-packages",
-        "rev": "50e6104658d745a15f30ecc2e7e87875930e8e1d",
+        "rev": "05c9f8fb28fde6e46d8768ce396a4482883d6bab",
         "type": "github"
       },
       "original": {
@@ -170,51 +170,14 @@
         "type": "github"
       }
     },
-    "ghc98X": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1696643148,
-        "narHash": "sha256-E02DfgISH7EvvNAu0BHiPvl1E5FGMDi0pWdNZtIBC9I=",
-        "ref": "ghc-9.8",
-        "rev": "443e870d977b1ab6fc05f47a9a17bc49296adbd6",
-        "revCount": 61642,
-        "submodules": true,
-        "type": "git",
-        "url": "https://gitlab.haskell.org/ghc/ghc"
-      },
-      "original": {
-        "ref": "ghc-9.8",
-        "submodules": true,
-        "type": "git",
-        "url": "https://gitlab.haskell.org/ghc/ghc"
-      }
-    },
-    "ghc99": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1701580282,
-        "narHash": "sha256-drA01r3JrXnkKyzI+owMZGxX0JameMzjK0W5jJE/+V4=",
-        "ref": "refs/heads/master",
-        "rev": "f5eb0f2982e9cf27515e892c4bdf634bcfb28459",
-        "revCount": 62197,
-        "submodules": true,
-        "type": "git",
-        "url": "https://gitlab.haskell.org/ghc/ghc"
-      },
-      "original": {
-        "submodules": true,
-        "type": "git",
-        "url": "https://gitlab.haskell.org/ghc/ghc"
-      }
-    },
     "hackage": {
       "flake": false,
       "locked": {
-        "lastModified": 1710721411,
-        "narHash": "sha256-0B1YATLPUKKOexhhfSFkTQlZH6o4yWJ/0WJeyZMxBKg=",
+        "lastModified": 1725409900,
+        "narHash": "sha256-XfSA7YyjHUfuNsCw4cE6p0kQcmrJgQq3nW36Cw/PAv0=",
         "owner": "input-output-hk",
         "repo": "hackage.nix",
-        "rev": "99719945242bc0c965560ed708868aa088748524",
+        "rev": "d86e544dec33ce5fb0ad3981be91074d397b700d",
         "type": "github"
       },
       "original": {
@@ -232,8 +195,6 @@
         "cardano-shell": "cardano-shell",
         "flake-compat": "flake-compat",
         "ghc-8.6.5-iohk": "ghc-8.6.5-iohk",
-        "ghc98X": "ghc98X",
-        "ghc99": "ghc99",
         "hackage": "hackage",
         "hls-1.10": "hls-1.10",
         "hls-2.0": "hls-2.0",
@@ -242,10 +203,12 @@
         "hls-2.4": "hls-2.4",
         "hls-2.5": "hls-2.5",
         "hls-2.6": "hls-2.6",
+        "hls-2.7": "hls-2.7",
+        "hls-2.8": "hls-2.8",
+        "hls-2.9": "hls-2.9",
         "hpc-coveralls": "hpc-coveralls",
         "hydra": "hydra",
         "iserv-proxy": "iserv-proxy",
-        "nix-tools-static": "nix-tools-static",
         "nixpkgs": [
           "haskellNix",
           "nixpkgs-unstable"
@@ -257,16 +220,17 @@
         "nixpkgs-2211": "nixpkgs-2211",
         "nixpkgs-2305": "nixpkgs-2305",
         "nixpkgs-2311": "nixpkgs-2311",
+        "nixpkgs-2405": "nixpkgs-2405",
         "nixpkgs-unstable": "nixpkgs-unstable",
         "old-ghc-nix": "old-ghc-nix",
         "stackage": "stackage"
       },
       "locked": {
-        "lastModified": 1708649400,
-        "narHash": "sha256-iDwTrACFFetPuTc0efdZ5pukmMMj/e9rPIYAUJxSo1E=",
+        "lastModified": 1725411053,
+        "narHash": "sha256-cW999pULNLOZHlV9sqBFIrWTkSxuVAVR6xJR7GndHdQ=",
         "owner": "input-output-hk",
         "repo": "haskell.nix",
-        "rev": "a3e36bb1cc1f4ab1dbe1b12d5bf68220ba3daf64",
+        "rev": "63783ecc949e99b2396ca821275cee26385adaba",
         "type": "github"
       },
       "original": {
@@ -394,6 +358,57 @@
         "type": "github"
       }
     },
+    "hls-2.7": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1708965829,
+        "narHash": "sha256-LfJ+TBcBFq/XKoiNI7pc4VoHg4WmuzsFxYJ3Fu+Jf+M=",
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "50322b0a4aefb27adc5ec42f5055aaa8f8e38001",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "2.7.0.0",
+        "repo": "haskell-language-server",
+        "type": "github"
+      }
+    },
+    "hls-2.8": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1715153580,
+        "narHash": "sha256-Vi/iUt2pWyUJlo9VrYgTcbRviWE0cFO6rmGi9rmALw0=",
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "dd1be1beb16700de59e0d6801957290bcf956a0a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "2.8.0.0",
+        "repo": "haskell-language-server",
+        "type": "github"
+      }
+    },
+    "hls-2.9": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1718469202,
+        "narHash": "sha256-THXSz+iwB1yQQsr/PY151+2GvtoJnTIB2pIQ4OzfjD4=",
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "40891bccb235ebacce020b598b083eab9dda80f1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "2.9.0.0",
+        "repo": "haskell-language-server",
+        "type": "github"
+      }
+    },
     "hpc-coveralls": {
       "flake": false,
       "locked": {
@@ -475,18 +490,18 @@
     "iserv-proxy": {
       "flake": false,
       "locked": {
-        "lastModified": 1691634696,
-        "narHash": "sha256-MZH2NznKC/gbgBu8NgIibtSUZeJ00HTLJ0PlWKCBHb0=",
-        "ref": "hkm/remote-iserv",
-        "rev": "43a979272d9addc29fbffc2e8542c5d96e993d73",
-        "revCount": 14,
-        "type": "git",
-        "url": "https://gitlab.haskell.org/hamishmack/iserv-proxy.git"
+        "lastModified": 1717479972,
+        "narHash": "sha256-7vE3RQycHI1YT9LHJ1/fUaeln2vIpYm6Mmn8FTpYeVo=",
+        "owner": "stable-haskell",
+        "repo": "iserv-proxy",
+        "rev": "2ed34002247213fc435d0062350b91bab920626e",
+        "type": "github"
       },
       "original": {
-        "ref": "hkm/remote-iserv",
-        "type": "git",
-        "url": "https://gitlab.haskell.org/hamishmack/iserv-proxy.git"
+        "owner": "stable-haskell",
+        "ref": "iserv-syms",
+        "repo": "iserv-proxy",
+        "type": "github"
       }
     },
     "lowdown-src": {
@@ -523,23 +538,6 @@
         "owner": "NixOS",
         "ref": "2.11.0",
         "repo": "nix",
-        "type": "github"
-      }
-    },
-    "nix-tools-static": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1706266250,
-        "narHash": "sha256-9t+GRk3eO9muCtKdNAwBtNBZ5dH1xHcnS17WaQyftwA=",
-        "owner": "input-output-hk",
-        "repo": "haskell-nix-example",
-        "rev": "580cb6db546a7777dad3b9c0fa487a366c045c4e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "input-output-hk",
-        "ref": "nix",
-        "repo": "haskell-nix-example",
         "type": "github"
       }
     },
@@ -656,11 +654,11 @@
     },
     "nixpkgs-2305": {
       "locked": {
-        "lastModified": 1701362232,
-        "narHash": "sha256-GVdzxL0lhEadqs3hfRLuj+L1OJFGiL/L7gCcelgBlsw=",
+        "lastModified": 1705033721,
+        "narHash": "sha256-K5eJHmL1/kev6WuqyqqbS1cdNnSidIZ3jeqJ7GbrYnQ=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "d2332963662edffacfddfad59ff4f709dde80ffe",
+        "rev": "a1982c92d8980a0114372973cbdfe0a307f1bdea",
         "type": "github"
       },
       "original": {
@@ -672,16 +670,32 @@
     },
     "nixpkgs-2311": {
       "locked": {
-        "lastModified": 1701386440,
-        "narHash": "sha256-xI0uQ9E7JbmEy/v8kR9ZQan6389rHug+zOtZeZFiDJk=",
+        "lastModified": 1719957072,
+        "narHash": "sha256-gvFhEf5nszouwLAkT9nWsDzocUTqLWHuL++dvNjMp9I=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "293822e55ec1872f715a66d0eda9e592dc14419f",
+        "rev": "7144d6241f02d171d25fba3edeaf15e0f2592105",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "ref": "nixpkgs-23.11-darwin",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-2405": {
+      "locked": {
+        "lastModified": 1720122915,
+        "narHash": "sha256-Nby8WWxj0elBu1xuRaUcRjPi/rU3xVbkAt2kj4QwX2U=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "835cf2d3f37989c5db6585a28de967a667a75fb1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-24.05-darwin",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -704,17 +718,17 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1694822471,
-        "narHash": "sha256-6fSDCj++lZVMZlyqOe9SIOL8tYSBz1bI8acwovRwoX8=",
+        "lastModified": 1720181791,
+        "narHash": "sha256-i4vJL12/AdyuQuviMMd1Hk2tsGt02hDNhA0Zj1m16N8=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "47585496bcb13fb72e4a90daeea2f434e2501998",
+        "rev": "4284c2b73c8bce4b46a6adf23e16d9e2ec8da4bb",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
         "repo": "nixpkgs",
-        "rev": "47585496bcb13fb72e4a90daeea2f434e2501998",
         "type": "github"
       }
     },
@@ -801,11 +815,11 @@
     "stackage": {
       "flake": false,
       "locked": {
-        "lastModified": 1708646943,
-        "narHash": "sha256-2yKh9HEWW+QvmUClepBuEQY0hgcPvCVoVHgrl3QPg8k=",
+        "lastModified": 1725408838,
+        "narHash": "sha256-tHw95xcMElCqI6xOLmdTAEvQ0/4IS7WBZc+RF7HT/uk=",
         "owner": "input-output-hk",
         "repo": "stackage.nix",
-        "rev": "6cd41c982e508c0ea3bb872ebccfdd7a65a58b2b",
+        "rev": "2ab3b5a823933ef199a289fbf39bbf0da0023100",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -70,6 +70,7 @@
             }
             // lib.optionalAttrs (config.compiler-nix-name == defaultCompiler) {
               # tools that work only with default compiler
+              fourmolu = "0.14.0.0";
               haskell-language-server.src = nixpkgs.haskell-nix.sources."hls-2.9";
               hlint = "3.8";
               stylish-haskell = "0.14.6.0";

--- a/flake.nix
+++ b/flake.nix
@@ -41,7 +41,7 @@
         inherit (nixpkgs) lib;
 
         # see flake `variants` below for alternative compilers
-        defaultCompiler = "ghc964";
+        defaultCompiler = "ghc966";
         # We use cabalProject' to ensure we don't build the plan for
         # all systems.
         cabalProject = nixpkgs.haskell-nix.cabalProject' ({config, ...}: {
@@ -65,14 +65,14 @@
           # tools we want in our shell, from hackage
           shell.tools =
             {
-              cabal = "3.10.2.0";
-              ghcid = "0.8.8";
+              cabal = "3.10.3.0";
+              ghcid = "0.8.9";
             }
             // lib.optionalAttrs (config.compiler-nix-name == defaultCompiler) {
               # tools that work only with default compiler
-              haskell-language-server.src = nixpkgs.haskell-nix.sources."hls-2.6";
-              hlint = "3.6.1";
-              stylish-haskell = "0.14.5.0";
+              haskell-language-server.src = nixpkgs.haskell-nix.sources."hls-2.9";
+              hlint = "3.8";
+              stylish-haskell = "0.14.6.0";
             };
           # and from nixpkgs or other inputs
           shell.nativeBuildInputs = with nixpkgs; [ gh jq yq-go ];

--- a/fourmolu.yaml
+++ b/fourmolu.yaml
@@ -1,0 +1,16 @@
+indentation: 2
+function-arrows: trailing
+comma-style: leading
+import-export-style: diff-friendly
+indent-wheres: true
+record-brace-space: true
+newlines-between-decls: 1
+haddock-style: single-line
+haddock-style-module:
+let-style: auto
+in-style: right-align
+unicode: never
+respectful: true
+fixities: []
+single-constraint-parens: never
+column-limit: 100


### PR DESCRIPTION
Brings faucet up to cardano-api and cardano-cli level of cardano-node `9.1`

* Bumps haskellNix and CHaP nix pins; ghc, cabal, ghcid, hls, hlint, stylish-haskell versions
* Bumps cabal indexes, cardano-api|cli cabal pins to match node `9.1.1`
* Fixes applied for upstream package breaking changes
* Removes cardano-address srp and adjust ghc opts
* Fixes failing ci mingw32 builds
* Applies hlint suggested changes
* Applies fourmolu config and formatting changes