### PR TITLE
Update to cardano-node 10.6

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -13,8 +13,8 @@ repository cardano-haskell-packages
 -- See CONTRIBUTING for information about these, including some Nix commands
 -- you need to run if you change them
 index-state:
-  , hackage.haskell.org 2024-10-25T16:28:05Z
-  , cardano-haskell-packages 2024-10-25T16:50:00Z
+  , hackage.haskell.org 2026-01-15T00:29:38Z
+  , cardano-haskell-packages 2026-01-09T12:04:47Z
 
 packages:
   cardano-faucet

--- a/cardano-faucet/cardano-faucet.cabal
+++ b/cardano-faucet/cardano-faucet.cabal
@@ -63,7 +63,7 @@ library
                       , MissingH
                       , bytestring
                       , cardano-addresses  >= 4
-                      , cardano-api       ^>= 10.16
+                      , cardano-api       ^>= 10.19
                       , cardano-cli
                       , cardano-prelude
                       , containers

--- a/cardano-faucet/cardano-faucet.cabal
+++ b/cardano-faucet/cardano-faucet.cabal
@@ -1,7 +1,7 @@
 cabal-version: 3.0
 
 name:                   cardano-faucet
-version:                10.1
+version:                10.6
 description:            The Cardano command-line interface.
 author:                 IOHK
 maintainer:             operations@iohk.io

--- a/cardano-faucet/cardano-faucet.cabal
+++ b/cardano-faucet/cardano-faucet.cabal
@@ -58,11 +58,12 @@ library
                         Cardano.Faucet.Web
                         Paths_cardano_faucet
 
-  build-depends:        aeson              >= 1.5.6.0
+  build-depends:        aeson              >= 2
+                      , aeson-pretty
                       , MissingH
                       , bytestring
-                      , cardano-addresses ^>= 3.12.0
-                      , cardano-api       ^>= 10.1.0.0
+                      , cardano-addresses  >= 4
+                      , cardano-api       ^>= 10.16
                       , cardano-cli
                       , cardano-prelude
                       , containers
@@ -77,6 +78,7 @@ library
                       , ouroboros-network-protocols
                       , parsec
                       , protolude
+                      , rio
                       , servant-client
                       , servant-server
                       , split

--- a/cardano-faucet/src/Cardano/Faucet.hs
+++ b/cardano-faucet/src/Cardano/Faucet.hs
@@ -41,7 +41,9 @@ import Cardano.Api (
   TxInMode,
   UTxO (unUTxO),
   connectToLocalNode,
+  docToText,
   getVerificationKey,
+  prettyException,
   serialiseAddress,
  )
 import Cardano.Api.Byron ()
@@ -60,7 +62,8 @@ import Cardano.Api.Shelley (
   makeStakeAddress,
   verificationKeyHash,
  )
-import Cardano.CLI.Run.Address (buildShelleyAddress)
+import Cardano.CLI.Compatible.Exception (CIO, CustomCliException (..))
+import Cardano.CLI.EraIndependent.Address.Run (buildShelleyAddress)
 import Cardano.Faucet.Misc
 import Cardano.Faucet.Types (
   FaucetConfigFile (..),
@@ -105,6 +108,7 @@ import Ouroboros.Network.Protocol.LocalTxMonitor.Client qualified as CTxMon
 import Ouroboros.Network.Protocol.LocalTxSubmission.Client qualified as Net.Tx
 import Paths_cardano_faucet (getDataFileName)
 import Protolude (print, readFile)
+import RIO (runRIO)
 import Servant
 import System.Environment (lookupEnv)
 import System.IO (BufferMode (LineBuffering), hSetBuffering)
@@ -330,12 +334,22 @@ newFaucetState fsConfig fsTxQueue = do
     fsPaymentVkey = pay_vkey
     fsBucketSizes = findAllSizes fsConfig
     fsNetwork = fcfNetwork fsConfig
-  fsOwnAddress <-
-    withExceptT FaucetErrorAddr
-      $ AddressShelley
-      <$> buildShelleyAddress (castVerificationKey pay_vkey) Nothing fsNetwork
+
+  fsOwnAddress <- 
+    AddressShelley <$>
+    runInCIO () (buildShelleyAddress (castVerificationKey pay_vkey) Nothing fsNetwork)
+
   pure $ FaucetState {..}
 
+runInCIO :: env -> CIO env action -> ExceptT FaucetError IO action
+runInCIO env action = 
+  ExceptT $ 
+    fmap Right (runRIO env action) 
+      `catch` \(e :: CustomCliException) -> pure $ Left (asFaucetError e)
+
+  where
+    asFaucetError = FaucetErrorTodo2 . docToText . prettyException
+    
 finish :: IO (Net.Query.ClientStAcquired block point query IO ())
 finish = do
   void . forever $ threadDelay 43200 {- day in seconds -}

--- a/cardano-faucet/src/Cardano/Faucet.hs
+++ b/cardano-faucet/src/Cardano/Faucet.hs
@@ -41,28 +41,27 @@ import Cardano.Api (
   TxInMode,
   UTxO (unUTxO),
   connectToLocalNode,
-  docToText,
   getVerificationKey,
-  prettyException,
   serialiseAddress,
  )
 import Cardano.Api.Byron ()
 import Cardano.Api.Ledger qualified as L
 
-import Cardano.Api.Shelley (
-  LocalTxMonitorClient (..),
-  NetworkId,
-  PoolId,
+import Cardano.Api.Network.IPC (LocalTxMonitorClient (..))
+import Cardano.Api.Network (NetworkId)
+import Cardano.Api.Certificate (PoolId)
+import Cardano.Api.Key (
   SigningKey (StakeExtendedSigningKey),
-  SlotNo,
-  StakeAddress,
-  StakeCredential (StakeCredentialByKey),
   StakeExtendedKey,
   castVerificationKey,
-  makeStakeAddress,
   verificationKeyHash,
  )
-import Cardano.CLI.Compatible.Exception (CIO, CustomCliException (..))
+import Cardano.Api.Block (SlotNo)
+import Cardano.Api.Address (
+  StakeAddress,
+  StakeCredential (StakeCredentialByKey),
+  makeStakeAddress,
+ )
 import Cardano.CLI.EraIndependent.Address.Run (buildShelleyAddress)
 import Cardano.Faucet.Misc
 import Cardano.Faucet.Types (
@@ -108,7 +107,6 @@ import Ouroboros.Network.Protocol.LocalTxMonitor.Client qualified as CTxMon
 import Ouroboros.Network.Protocol.LocalTxSubmission.Client qualified as Net.Tx
 import Paths_cardano_faucet (getDataFileName)
 import Protolude (print, readFile)
-import RIO (runRIO)
 import Servant
 import System.Environment (lookupEnv)
 import System.IO (BufferMode (LineBuffering), hSetBuffering)
@@ -335,21 +333,15 @@ newFaucetState fsConfig fsTxQueue = do
     fsBucketSizes = findAllSizes fsConfig
     fsNetwork = fcfNetwork fsConfig
 
-  fsOwnAddress <- 
-    AddressShelley <$>
-    runInCIO () (buildShelleyAddress (castVerificationKey pay_vkey) Nothing fsNetwork)
+  shelleyAddress <- 
+    withExceptT FaucetErrorTodo2 $
+      runInCIO () $ 
+          buildShelleyAddress (castVerificationKey pay_vkey) Nothing fsNetwork
+
+  let fsOwnAddress = AddressShelley shelleyAddress
 
   pure $ FaucetState {..}
 
-runInCIO :: env -> CIO env action -> ExceptT FaucetError IO action
-runInCIO env action = 
-  ExceptT $ 
-    fmap Right (runRIO env action) 
-      `catch` \(e :: CustomCliException) -> pure $ Left (asFaucetError e)
-
-  where
-    asFaucetError = FaucetErrorTodo2 . docToText . prettyException
-    
 finish :: IO (Net.Query.ClientStAcquired block point query IO ())
 finish = do
   void . forever $ threadDelay 43200 {- day in seconds -}

--- a/cardano-faucet/src/Cardano/Faucet/Misc.hs
+++ b/cardano-faucet/src/Cardano/Faucet/Misc.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE ImportQualifiedPost #-}
+{-# LANGUAGE GADTs #-}
 
 module Cardano.Faucet.Misc where
 
@@ -14,11 +15,10 @@ import Cardano.Api (
   valueToList,
  )
 import Cardano.Api.Ledger qualified as L
-import Cardano.Api.Shelley (AssetId (AssetId), selectLovelace)
+import Cardano.Api.Value (AssetId (AssetId), selectLovelace)
 import Cardano.Faucet.Types
 import Cardano.Prelude
 import Control.Monad.Trans.Except.Extra (left)
-import Data.Text qualified as T
 import Text.Parsec
 
 getValue :: TxOutValue era -> FaucetValue
@@ -55,7 +55,7 @@ faucetValueToLovelace (FaucetValueMultiAsset ll _token) = ll
 faucetValueToLovelace (FaucetValueManyTokens ll) = ll
 
 parseAddress :: Text -> ExceptT FaucetWebError IO AddressAny
-parseAddress addr = case parse (parseAddressAny <* eof) "" (T.unpack addr) of
+parseAddress addr = case parse (parseAddressAny <* eof) "" addr of
   Right a -> return a
   Left e -> left $ FaucetWebErrorInvalidAddress addr (show e)
 

--- a/cardano-faucet/src/Cardano/Faucet/TxUtils.hs
+++ b/cardano-faucet/src/Cardano/Faucet/TxUtils.hs
@@ -29,21 +29,20 @@ import Cardano.Api (
   TxWithdrawals (TxWithdrawalsNone),
   Witness (KeyWitness),
   defaultTxValidityUpperBound,
-  docToText,
   getTxId,
   makeShelleyKeyWitness,
   makeSignedTransaction, txMintValueToValue,
  )
 import qualified Cardano.Api.Ledger as L
-import Cardano.Api.Shelley (Value, createAndValidateTransactionBody, lovelaceToValue)
-import Cardano.CLI.EraBased.Transaction.Run
+import Cardano.Api.Tx (createAndValidateTransactionBody)
+import Cardano.Api.Value (Value, lovelaceToValue)
 import Cardano.CLI.Type.Common
-import Cardano.CLI.Type.Error.TxCmdError
 import Cardano.Faucet.Misc (faucetValueToLovelace, getValue)
 import Cardano.Faucet.Types (FaucetValue, FaucetWebError (..))
 import Cardano.Faucet.Utils
 import Cardano.Prelude hiding ((%))
 import Control.Monad.Trans.Except.Extra (left)
+import Cardano.CLI.Compatible.Transaction.TxOut (toTxOutInAnyEra)
 
 newtype Fee = Fee L.Coin
 
@@ -79,7 +78,7 @@ txBuild sbe (txin, txout) addressOrOutputs certs minting (Fee fixedFee) = do
       <*> pure TxInsCollateralNone
       <*> pure TxInsReferenceNone
       <*> mapM
-        (\x -> withExceptT (FaucetWebErrorTodo . docToText . renderTxCmdError) $ toTxOutInAnyEra sbe x)
+        (\x -> withExceptT FaucetWebErrorTodo $ runInCIO () $ toTxOutInAnyEra sbe x)
         (getTxOuts addressOrOutputs)
       <*> pure TxTotalCollateralNone
       <*> pure TxReturnCollateralNone

--- a/cardano-faucet/src/Cardano/Faucet/TxUtils.hs
+++ b/cardano-faucet/src/Cardano/Faucet/TxUtils.hs
@@ -23,7 +23,6 @@ import Cardano.Api (
   TxOut (TxOut),
   TxReturnCollateral (TxReturnCollateralNone),
   TxScriptValidity (TxScriptValidityNone),
-  TxSupplementalDatums (..),
   TxTotalCollateral (TxTotalCollateralNone),
   TxUpdateProposal (TxUpdateProposalNone),
   TxValidityLowerBound (TxValidityNoLowerBound),
@@ -33,22 +32,18 @@ import Cardano.Api (
   docToText,
   getTxId,
   makeShelleyKeyWitness,
-  makeSignedTransaction,
+  makeSignedTransaction, txMintValueToValue,
  )
 import qualified Cardano.Api.Ledger as L
 import Cardano.Api.Shelley (Value, createAndValidateTransactionBody, lovelaceToValue)
-import Cardano.CLI.EraBased.Run.Transaction
-import Cardano.CLI.Types.Common
-import Cardano.CLI.Types.Errors.TxCmdError
+import Cardano.CLI.EraBased.Transaction.Run
+import Cardano.CLI.Type.Common
+import Cardano.CLI.Type.Error.TxCmdError
 import Cardano.Faucet.Misc (faucetValueToLovelace, getValue)
 import Cardano.Faucet.Types (FaucetValue, FaucetWebError (..))
 import Cardano.Faucet.Utils
 import Cardano.Prelude hiding ((%))
 import Control.Monad.Trans.Except.Extra (left)
-
-getMintedValue :: TxMintValue BuildTx era -> Value
-getMintedValue (TxMintValue _ val _) = val
-getMintedValue TxMintNone = mempty
 
 newtype Fee = Fee L.Coin
 
@@ -69,7 +64,7 @@ txBuild sbe (txin, txout) addressOrOutputs certs minting (Fee fixedFee) = do
     value = faucetValueToLovelace $ unwrap txout
     change :: L.Coin
     change = value - fixedFee
-    mintedValue = getMintedValue minting
+    mintedValue = txMintValueToValue minting
     -- TODO, add minted tokens
     changeValue :: Value
     changeValue = lovelaceToValue change <> mintedValue
@@ -93,7 +88,6 @@ txBuild sbe (txin, txout) addressOrOutputs certs minting (Fee fixedFee) = do
       <*> pure (defaultTxValidityUpperBound sbe)
       <*> pure TxMetadataNone
       <*> pure TxAuxScriptsNone
-      <*> pure (BuildTxWith TxSupplementalDataNone)
       <*> pure TxExtraKeyWitnessesNone
       <*> pure (BuildTxWith Nothing)
       <*> pure TxWithdrawalsNone

--- a/cardano-faucet/src/Cardano/Faucet/Types.hs
+++ b/cardano-faucet/src/Cardano/Faucet/Types.hs
@@ -77,7 +77,7 @@ import Cardano.Api.Shelley (
   StakeCredential,
   StakeExtendedKey,
  )
-import Cardano.CLI.Types.Errors.AddressCmdError
+import Cardano.CLI.Type.Error.AddressCmdError
 import Cardano.Mnemonic (getMkSomeMnemonicError, mkSomeMnemonic)
 import Cardano.Prelude
 import Control.Concurrent.STM (TMVar, TQueue)

--- a/cardano-faucet/src/Cardano/Faucet/Types.hs
+++ b/cardano-faucet/src/Cardano/Faucet/Types.hs
@@ -68,15 +68,11 @@ import Cardano.Api (
   docToText,
  )
 import Cardano.Api.Ledger qualified as L
-import Cardano.Api.Shelley (
-  AssetName (..),
-  NetworkId (Mainnet, Testnet),
-  NetworkMagic (NetworkMagic),
-  PoolId,
-  ShelleyWitnessSigningKey,
-  StakeCredential,
-  StakeExtendedKey,
- )
+import Cardano.Api.Address (StakeCredential, StakeExtendedKey)
+import Cardano.Api.Certificate (PoolId)
+import Cardano.Api.Network (NetworkId (Mainnet, Testnet), NetworkMagic (NetworkMagic))
+import Cardano.Api.Tx (ShelleyWitnessSigningKey)
+import Cardano.Api.Value (AssetName (..))
 import Cardano.CLI.Type.Error.AddressCmdError
 import Cardano.Mnemonic (getMkSomeMnemonicError, mkSomeMnemonic)
 import Cardano.Prelude
@@ -362,7 +358,7 @@ parseToken :: Aeson.Object -> Parser AssetName
 parseToken v = do
   mToken <- v .:? "token"
   case mToken of
-    Just t -> pure $ AssetName $ encodeUtf8 t
+    Just t -> pure $ UnsafeAssetName $ encodeUtf8 t
     Nothing -> v .: "tokenHex"
 
 instance Aeson.FromJSON FaucetToken where

--- a/cardano-faucet/src/Cardano/Faucet/Utils.hs
+++ b/cardano-faucet/src/Cardano/Faucet/Utils.hs
@@ -24,13 +24,15 @@ import Cardano.Api (
 import Cardano.Api.Ledger qualified as L
 import Cardano.Api.Shelley (ShelleyBasedEra (..))
 import Cardano.CLI.Json.Friendly qualified as CLI
-import Cardano.CLI.Types.MonadWarning qualified as CLI
+import Cardano.CLI.Type.MonadWarning qualified as CLI
 import Cardano.Faucet.Misc
 import Cardano.Faucet.Types
 import Cardano.Prelude hiding ((%))
 import Control.Concurrent.STM (TMVar, putTMVar, takeTMVar)
 import Control.Monad.Trans.Except.Extra (left)
+import Data.Aeson.Encode.Pretty qualified as Aeson
 import Data.ByteString qualified as BS
+import Data.ByteString.Lazy qualified as LBS
 import Data.Map.Strict qualified as Map
 import Prelude qualified
 
@@ -115,10 +117,11 @@ prettyFriendlyTx ::
   Tx era ->
   BS.ByteString
 prettyFriendlyTx sbe tx =
-  CLI.friendlyBS CLI.FriendlyJson prettyTxAeson
+  BS.concat . LBS.toChunks $ Aeson.encodePretty' jsonConfig prettyTxAeson
   where
     era = toCardanoEra sbe
     prettyTxAeson = fst $ runState (CLI.runWarningStateT $ CLI.friendlyTxImpl era tx) []
+    jsonConfig = Aeson.defConfig{Aeson.confCompare = compare}
 
 -- | @cardanoEraToShelleyBasedEra@ converts a 'CardanoEra' to a 'ShelleyBasedEra'
 -- or returns an error message if the era is not Shelley based.

--- a/cardano-faucet/src/Cardano/Faucet/Utils.hs
+++ b/cardano-faucet/src/Cardano/Faucet/Utils.hs
@@ -3,6 +3,8 @@
 {-# LANGUAGE ImportQualifiedPost #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
 
 module Cardano.Faucet.Utils where
 
@@ -19,11 +21,12 @@ import Cardano.Api (
   TxValidityUpperBound,
   defaultTxValidityUpperBound,
   shelleyBasedEraConstraints,
-  toCardanoEra,
+  toCardanoEra, docToText, prettyException,
  )
 import Cardano.Api.Ledger qualified as L
-import Cardano.Api.Shelley (ShelleyBasedEra (..))
-import Cardano.CLI.Json.Friendly qualified as CLI
+import Cardano.Api.Era (ShelleyBasedEra (..))
+import Cardano.CLI.Compatible.Exception (CIO, CustomCliException)
+import Cardano.CLI.Compatible.Json.Friendly qualified as CLI
 import Cardano.CLI.Type.MonadWarning qualified as CLI
 import Cardano.Faucet.Misc
 import Cardano.Faucet.Types
@@ -35,6 +38,7 @@ import Data.ByteString qualified as BS
 import Data.ByteString.Lazy qualified as LBS
 import Data.Map.Strict qualified as Map
 import Prelude qualified
+import RIO (runRIO)
 
 computeUtxoStats :: Map TxIn (TxOut CtxUTxO era) -> UtxoStats
 computeUtxoStats utxo = do
@@ -119,8 +123,7 @@ prettyFriendlyTx ::
 prettyFriendlyTx sbe tx =
   BS.concat . LBS.toChunks $ Aeson.encodePretty' jsonConfig prettyTxAeson
   where
-    era = toCardanoEra sbe
-    prettyTxAeson = fst $ runState (CLI.runWarningStateT $ CLI.friendlyTxImpl era tx) []
+    prettyTxAeson = fst $ runState (CLI.runWarningStateT $ CLI.friendlyTxImpl sbe tx) []
     jsonConfig = Aeson.defConfig{Aeson.confCompare = compare}
 
 -- | @cardanoEraToShelleyBasedEra@ converts a 'CardanoEra' to a 'ShelleyBasedEra'
@@ -134,3 +137,13 @@ cardanoEraToShelleyBasedEra = \case
   AlonzoEra -> Right ShelleyBasedEraAlonzo
   BabbageEra -> Right ShelleyBasedEraBabbage
   ConwayEra -> Right ShelleyBasedEraConway
+  DijkstraEra -> Right ShelleyBasedEraDijkstra
+
+runInCIO :: env -> CIO env action -> ExceptT Text IO action
+runInCIO env action = 
+  ExceptT $ 
+    fmap Right (runRIO env action) 
+      `catch` \(e :: CustomCliException) -> pure $ Left (asFaucetError e)
+
+  where
+    asFaucetError = docToText . prettyException

--- a/cardano-faucet/src/Cardano/Faucet/Web.hs
+++ b/cardano-faucet/src/Cardano/Faucet/Web.hs
@@ -23,7 +23,7 @@ import Cardano.Api.Shelley (
   PoolId,
   SimpleScriptOrReferenceInput (SScript),
  )
-import Cardano.CLI.Types.Common
+import Cardano.CLI.Type.Common
 import Cardano.Faucet.Misc (faucetValueToLovelace, parseAddress, stripMintingTokens, toFaucetValue)
 import Cardano.Faucet.TxUtils (Fee (..), makeAndSignTx)
 import Cardano.Faucet.Types (
@@ -75,6 +75,7 @@ import Servant.Client (
   mkClientEnv,
   runClientM,
  )
+import GHC.Exts (IsList(..))
 
 -- create recaptcha api keys at https://www.google.com/recaptcha/admin
 -- reCAPTCHA v2, "i am not a robot"
@@ -314,16 +315,27 @@ getOptionalMintOutput sbe fs (FaucetValueMultiAsset _ (FaucetMintToken (policy_i
   caseShelleyToAllegraOrMaryEraOnwards
     (\_ -> left $ FaucetWebErrorTodo "era earlier than mary not supported")
     ( \maryOnwards -> do
-        let
         languageSupportedInEra <- case scriptLanguageSupportedInEra sbe SimpleScriptLanguage of
           Just yes -> pure yes
           Nothing -> left $ FaucetWebErrorTodo "scripts not supported"
+
         let
           TokenState {tsAssetId, tsPolicyId, tsSimpleScript, tsPolicySKey} = getTokenState policy_index name fs
+
+        assetName <- case tsAssetId of
+            AdaAssetId -> left $ FaucetWebErrorTodo "Not a multi asset"
+            AssetId _ assetName -> pure assetName
+
+        let
+          assets = PolicyAssets $ Map.fromList [(assetName, quant)]
+          witnessProvided = BuildTxWith $ SimpleScriptWitness languageSupportedInEra (SScript tsSimpleScript)
           valueToMint = valueFromList [(tsAssetId, quant)]
-          witnessesProvidedMap = Map.fromList [(tsPolicyId, SimpleScriptWitness languageSupportedInEra (SScript tsSimpleScript))]
-          y = BuildTxWith witnessesProvidedMap
-        pure (valueToMint, TxMintValue maryOnwards valueToMint y, [WitnessPaymentExtendedKey tsPolicySKey])
+
+        pure 
+          (valueToMint
+          , TxMintValue maryOnwards (Map.fromList [(tsPolicyId, (assets, witnessProvided))])
+          , [WitnessPaymentExtendedKey tsPolicySKey]
+          )
     )
     sbe
 getOptionalMintOutput _ _ _ = pure (mempty, TxMintNone, [])
@@ -349,10 +361,15 @@ mintFreshTokens sbe fs@FaucetState {fsUtxoTMVar, fsPaymentSkey, fsOwnAddress} po
         languageSupportedInEra <- case scriptLanguageSupportedInEra sbe SimpleScriptLanguage of
           Just yes -> pure yes
           Nothing -> left $ FaucetWebErrorTodo "scripts not supported"
+        assetName <- case tsAssetId of
+            AdaAssetId -> left $ FaucetWebErrorTodo "Not a multi asset"
+            AssetId _ assetName -> pure assetName
         let
-          valueToMint = valueFromList [(tsAssetId, Quantity $ count * tx_out_count)]
-          witnessesProvidedMap = Map.fromList [(tsPolicyId, SimpleScriptWitness languageSupportedInEra (SScript tsSimpleScript))]
-          mint = TxMintValue supported valueToMint $ BuildTxWith witnessesProvidedMap
+          quant = Quantity (count * tx_out_count)
+          witnessProvided = BuildTxWith $ SimpleScriptWitness languageSupportedInEra (SScript tsSimpleScript)
+          valueToMint = valueFromList [(tsAssetId, quant)]
+          assets = PolicyAssets $ Map.fromList [(assetName, quant)]
+          mint = TxMintValue supported (Map.fromList [(tsPolicyId, (assets, witnessProvided))])
           -- value in each utxo being created
           outputValue = valueFromList [(AdaAssetId, Quantity 10_000_000), (tsAssetId, Quantity count)]
           outputValues = replicate (fromIntegral tx_out_count) outputValue
@@ -446,7 +463,7 @@ handleDelegateStake
         Left err -> left err
         Right ((stake_skey, creds), txinout) -> do
           let
-            poolKeyHash :: L.KeyHash 'L.StakePool L.StandardCrypto = unStakePoolKeyHash poolId
+            poolKeyHash :: L.KeyHash 'L.StakePool = unStakePoolKeyHash poolId
             requirements =
               caseShelleyToBabbageOrConwayEraOnwards
                 (\shelleyToBabbage -> StakeDelegationRequirementsPreConway shelleyToBabbage creds poolId)
@@ -454,14 +471,14 @@ handleDelegateStake
                 sbe
             cert = makeStakeAddressDelegationCertificate requirements
             stake_witness = WitnessStakeExtendedKey stake_skey
-            x = BuildTxWith [(creds, KeyWitness KeyWitnessForStakeAddr)]
+            x = BuildTxWith $ Just (creds, KeyWitness KeyWitnessForStakeAddr)
           (signedTx, txid) <-
             makeAndSignTx
               sbe
               txinout
               (Left fsOwnAddress)
               [fsPaymentSkey, stake_witness]
-              (TxCertificates sbe [cert] x)
+              (TxCertificates sbe $ fromList [(cert, x)])
               TxMintNone
               (Fee $ L.Coin 200_000)
           let

--- a/cardano-faucet/src/Cardano/Faucet/Web.hs
+++ b/cardano-faucet/src/Cardano/Faucet/Web.hs
@@ -18,11 +18,6 @@ import Cardano.Address.Derivation (Depth (PolicyK), XPrv)
 import Cardano.Address.Style.Shelley (Shelley, getKey)
 import Cardano.Api
 import Cardano.Api.Ledger qualified as L
-import Cardano.Api.Shelley (
-  Hash (unStakePoolKeyHash),
-  PoolId,
-  SimpleScriptOrReferenceInput (SScript),
- )
 import Cardano.CLI.Type.Common
 import Cardano.Faucet.Misc (faucetValueToLovelace, parseAddress, stripMintingTokens, toFaucetValue)
 import Cardano.Faucet.TxUtils (Fee (..), makeAndSignTx)
@@ -233,7 +228,7 @@ handleMintCoins era fs@FaucetState {fsTxQueue} addr fee output_count tokens_per_
         fs
         0
         addressAny
-        (AssetName "Testtoken")
+        (UnsafeAssetName "Testtoken")
         tokens_per_utxo
         output_count
         (Fee $ L.Coin fee)
@@ -608,7 +603,7 @@ handleMetrics FaucetState {fsUtxoTMVar, fsBucketSizes, fsConfig, fsStakeTMVar} =
         where
           L.Coin l = faucetValueToLovelace fv
       tokenAttributes :: FaucetToken -> [Maybe (Text, MetricValue)]
-      tokenAttributes (FaucetToken (AssetId (PolicyId scripthash) (AssetName _tokenname), _quant)) =
+      tokenAttributes (FaucetToken (AssetId (PolicyId scripthash) (UnsafeAssetName _tokenname), _quant)) =
         [ Just ("policyid", MetricValueStr $ serialiseToRawBytesHexText scripthash)
         -- has escaping issues, T_1\n breaks prometheus
         -- , Just ("tokenname", MetricValueStr $ T.decodeLatin1 tokenname)

--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "CHaP": {
       "flake": false,
       "locked": {
-        "lastModified": 1729772546,
-        "narHash": "sha256-8q7n71y/pF/JJDSOEQIwb1RpCkIuKULksC3Fjg+5ZF0=",
+        "lastModified": 1768416233,
+        "narHash": "sha256-i2c7coWF4U8y9WwiwAQGu3RkLlJJUQgomBPqsuZ7aNc=",
         "owner": "IntersectMBO",
         "repo": "cardano-haskell-packages",
-        "rev": "44b0dee389dacaa00c8265a383d7bf13a642a153",
+        "rev": "cb466bebf83011b95108c2bb1d2a7514446fc11b",
         "type": "github"
       },
       "original": {
@@ -36,17 +36,17 @@
     "blst": {
       "flake": false,
       "locked": {
-        "lastModified": 1656163412,
-        "narHash": "sha256-xero1aTe2v4IhWIJaEDUsVDOfE77dOV5zKeHWntHogY=",
+        "lastModified": 1739372843,
+        "narHash": "sha256-IlbNMLBjs/dvGogcdbWQIL+3qwy7EXJbIDpo4xBd4bY=",
         "owner": "supranational",
         "repo": "blst",
-        "rev": "03b5124029979755c752eec45f3c29674b558446",
+        "rev": "8c7db7fe8d2ce6e76dc398ebd4d475c0ec564355",
         "type": "github"
       },
       "original": {
         "owner": "supranational",
+        "ref": "v0.3.14",
         "repo": "blst",
-        "rev": "03b5124029979755c752eec45f3c29674b558446",
         "type": "github"
       }
     },
@@ -153,31 +153,47 @@
         "type": "github"
       }
     },
-    "ghc-8.6.5-iohk": {
+    "hackage": {
       "flake": false,
       "locked": {
-        "lastModified": 1600920045,
-        "narHash": "sha256-DO6kxJz248djebZLpSzTGD6s8WRpNI9BTwUeOf5RwY8=",
+        "lastModified": 1768437443,
+        "narHash": "sha256-9t0oZEnM0WyWAXgEBMu8zjxuBevGQ87bfcj1MSnIIp8=",
         "owner": "input-output-hk",
-        "repo": "ghc",
-        "rev": "95713a6ecce4551240da7c96b6176f980af75cae",
+        "repo": "hackage.nix",
+        "rev": "09eba93b04a4a450b31a93f1c19562b05212ff65",
         "type": "github"
       },
       "original": {
         "owner": "input-output-hk",
-        "ref": "release/8.6.5-iohk",
-        "repo": "ghc",
+        "repo": "hackage.nix",
         "type": "github"
       }
     },
-    "hackage": {
+    "hackage-for-stackage": {
       "flake": false,
       "locked": {
-        "lastModified": 1727828875,
-        "narHash": "sha256-gpGSsaS9kTwUUi3KNLwHbAPKZiXjrg1tYKhMj/31Sd4=",
+        "lastModified": 1768436846,
+        "narHash": "sha256-tFkgSabBsoRH64cJp5PQHh9CLbQIeH3CM8xkIiivKqg=",
         "owner": "input-output-hk",
         "repo": "hackage.nix",
-        "rev": "f24239b969ef8bef3e4887a17efd2ef6ca3016ef",
+        "rev": "3839b664241b53d5ad659273a53bb4e1ef740357",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "ref": "for-stackage",
+        "repo": "hackage.nix",
+        "type": "github"
+      }
+    },
+    "hackage-internal": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1750307553,
+        "narHash": "sha256-iiafNoeLHwlSLQTyvy8nPe2t6g5AV4PPcpMeH/2/DLs=",
+        "owner": "input-output-hk",
+        "repo": "hackage.nix",
+        "rev": "f7867baa8817fab296528f4a4ec39d1c7c4da4f3",
         "type": "github"
       },
       "original": {
@@ -194,10 +210,15 @@
         "cabal-36": "cabal-36",
         "cardano-shell": "cardano-shell",
         "flake-compat": "flake-compat",
-        "ghc-8.6.5-iohk": "ghc-8.6.5-iohk",
         "hackage": "hackage",
+        "hackage-for-stackage": "hackage-for-stackage",
+        "hackage-internal": "hackage-internal",
+        "hls": "hls",
         "hls-1.10": "hls-1.10",
         "hls-2.0": "hls-2.0",
+        "hls-2.10": "hls-2.10",
+        "hls-2.11": "hls-2.11",
+        "hls-2.12": "hls-2.12",
         "hls-2.2": "hls-2.2",
         "hls-2.3": "hls-2.3",
         "hls-2.4": "hls-2.4",
@@ -207,35 +228,48 @@
         "hls-2.8": "hls-2.8",
         "hls-2.9": "hls-2.9",
         "hpc-coveralls": "hpc-coveralls",
-        "hydra": "hydra",
         "iserv-proxy": "iserv-proxy",
         "nixpkgs": [
           "haskellNix",
           "nixpkgs-unstable"
         ],
-        "nixpkgs-2003": "nixpkgs-2003",
-        "nixpkgs-2105": "nixpkgs-2105",
-        "nixpkgs-2111": "nixpkgs-2111",
-        "nixpkgs-2205": "nixpkgs-2205",
-        "nixpkgs-2211": "nixpkgs-2211",
         "nixpkgs-2305": "nixpkgs-2305",
         "nixpkgs-2311": "nixpkgs-2311",
         "nixpkgs-2405": "nixpkgs-2405",
+        "nixpkgs-2411": "nixpkgs-2411",
+        "nixpkgs-2505": "nixpkgs-2505",
+        "nixpkgs-2511": "nixpkgs-2511",
         "nixpkgs-unstable": "nixpkgs-unstable",
         "old-ghc-nix": "old-ghc-nix",
         "stackage": "stackage"
       },
       "locked": {
-        "lastModified": 1727830257,
-        "narHash": "sha256-MWSPrlbnki4181gdUPiEf/skLi1K+k/CEATxDBfrJo8=",
+        "lastModified": 1768438327,
+        "narHash": "sha256-je+YEW+sVM5dE2iRZkyYdRzfKTAdit+b0GSV5a6j9EA=",
         "owner": "input-output-hk",
         "repo": "haskell.nix",
-        "rev": "e1b4513aedd0b3055b34171c60a4cc6fe898b318",
+        "rev": "62124249de60c2a4ab096100f302744b2ee9921d",
         "type": "github"
       },
       "original": {
         "owner": "input-output-hk",
         "repo": "haskell.nix",
+        "type": "github"
+      }
+    },
+    "hls": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1741604408,
+        "narHash": "sha256-tuq3+Ip70yu89GswZ7DSINBpwRprnWnl6xDYnS4GOsc=",
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "682d6894c94087da5e566771f25311c47e145359",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "repo": "haskell-language-server",
         "type": "github"
       }
     },
@@ -269,6 +303,57 @@
       "original": {
         "owner": "haskell",
         "ref": "2.0.0.1",
+        "repo": "haskell-language-server",
+        "type": "github"
+      }
+    },
+    "hls-2.10": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1743069404,
+        "narHash": "sha256-q4kDFyJDDeoGqfEtrZRx4iqMVEC2MOzCToWsFY+TOzY=",
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "2318c61db3a01e03700bd4b05665662929b7fe8b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "2.10.0.0",
+        "repo": "haskell-language-server",
+        "type": "github"
+      }
+    },
+    "hls-2.11": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1747306193,
+        "narHash": "sha256-/MmtpF8+FyQlwfKHqHK05BdsxC9LHV70d/FiMM7pzBM=",
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "46ef4523ea4949f47f6d2752476239f1c6d806fe",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "2.11.0.0",
+        "repo": "haskell-language-server",
+        "type": "github"
+      }
+    },
+    "hls-2.12": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1758709460,
+        "narHash": "sha256-xkI8MIIVEVARskfWbGAgP5sHG/lyeKnkm0LIOJ19X5w=",
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "7d983de4fa7ff54369f6dd31444bdb9869aec83e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "2.12.0.0",
         "repo": "haskell-language-server",
         "type": "github"
       }
@@ -395,11 +480,11 @@
     "hls-2.9": {
       "flake": false,
       "locked": {
-        "lastModified": 1720003792,
-        "narHash": "sha256-qnDx8Pk0UxtoPr7BimEsAZh9g2WuTuMB/kGqnmdryKs=",
+        "lastModified": 1719993701,
+        "narHash": "sha256-wy348++MiMm/xwtI9M3vVpqj2qfGgnDcZIGXw8sF1sA=",
         "owner": "haskell",
         "repo": "haskell-language-server",
-        "rev": "0c1817cb2babef0765e4e72dd297c013e8e3d12b",
+        "rev": "90319a7e62ab93ab65a95f8f2bcf537e34dae76a",
         "type": "github"
       },
       "original": {
@@ -425,29 +510,6 @@
         "type": "github"
       }
     },
-    "hydra": {
-      "inputs": {
-        "nix": "nix",
-        "nixpkgs": [
-          "haskellNix",
-          "hydra",
-          "nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1671755331,
-        "narHash": "sha256-hXsgJj0Cy0ZiCiYdW2OdBz5WmFyOMKuw4zyxKpgUKm4=",
-        "owner": "NixOS",
-        "repo": "hydra",
-        "rev": "f48f00ee6d5727ae3e488cbf9ce157460853fea8",
-        "type": "github"
-      },
-      "original": {
-        "id": "hydra",
-        "type": "indirect"
-      }
-    },
     "incl": {
       "inputs": {
         "nixlib": "nixlib"
@@ -469,16 +531,16 @@
     "iohkNix": {
       "inputs": {
         "blst": "blst",
-        "nixpkgs": "nixpkgs_2",
+        "nixpkgs": "nixpkgs",
         "secp256k1": "secp256k1",
         "sodium": "sodium"
       },
       "locked": {
-        "lastModified": 1702362799,
-        "narHash": "sha256-cU8cZXNuo5GRwrSvWqdaqoW5tJ2HWwDEOvWwIVPDPmo=",
+        "lastModified": 1767797951,
+        "narHash": "sha256-74YzTQnjU8zXjFsSGNTElT/JrjEJ+UWxXP4W/aqegKk=",
         "owner": "input-output-hk",
         "repo": "iohk-nix",
-        "rev": "b426fb9e0b109a9d1dd2e1476f9e0bd8bb715142",
+        "rev": "a489231f4a6749fe6a81a63af7159d75bdaff700",
         "type": "github"
       },
       "original": {
@@ -490,54 +552,17 @@
     "iserv-proxy": {
       "flake": false,
       "locked": {
-        "lastModified": 1717479972,
-        "narHash": "sha256-7vE3RQycHI1YT9LHJ1/fUaeln2vIpYm6Mmn8FTpYeVo=",
+        "lastModified": 1755243078,
+        "narHash": "sha256-GLbl1YaohKdpzZVJFRdcI1O1oE3F3uBer4lFv3Yy0l8=",
         "owner": "stable-haskell",
         "repo": "iserv-proxy",
-        "rev": "2ed34002247213fc435d0062350b91bab920626e",
+        "rev": "150605195cb7183a6fb7bed82f23fedf37c6f52a",
         "type": "github"
       },
       "original": {
         "owner": "stable-haskell",
         "ref": "iserv-syms",
         "repo": "iserv-proxy",
-        "type": "github"
-      }
-    },
-    "lowdown-src": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1633514407,
-        "narHash": "sha256-Dw32tiMjdK9t3ETl5fzGrutQTzh2rufgZV4A/BbxuD4=",
-        "owner": "kristapsdz",
-        "repo": "lowdown",
-        "rev": "d2c2b44ff6c27b936ec27358a2653caaef8f73b8",
-        "type": "github"
-      },
-      "original": {
-        "owner": "kristapsdz",
-        "repo": "lowdown",
-        "type": "github"
-      }
-    },
-    "nix": {
-      "inputs": {
-        "lowdown-src": "lowdown-src",
-        "nixpkgs": "nixpkgs",
-        "nixpkgs-regression": "nixpkgs-regression"
-      },
-      "locked": {
-        "lastModified": 1661606874,
-        "narHash": "sha256-9+rpYzI+SmxJn+EbYxjGv68Ucp22bdFUSy/4LkHkkDQ=",
-        "owner": "NixOS",
-        "repo": "nix",
-        "rev": "11e45768b34fdafdcf019ddbd337afa16127ff0f",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "2.11.0",
-        "repo": "nix",
         "type": "github"
       }
     },
@@ -558,96 +583,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1657693803,
-        "narHash": "sha256-G++2CJ9u0E7NNTAi9n5G8TdDmGJXcIjkJ3NF8cetQB8=",
-        "owner": "NixOS",
+        "lastModified": 1751071626,
+        "narHash": "sha256-/uHE/AD2qGq4QLigWAnBHiVvpVXB04XAfrOtw8JMv+Y=",
+        "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "365e1b3a859281cf11b94f87231adeabbdd878a2",
+        "rev": "a47938d89bdf8e279ad432bd6a473cf4c430f48c",
         "type": "github"
       },
       "original": {
-        "owner": "NixOS",
-        "ref": "nixos-22.05-small",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs-2003": {
-      "locked": {
-        "lastModified": 1620055814,
-        "narHash": "sha256-8LEHoYSJiL901bTMVatq+rf8y7QtWuZhwwpKE2fyaRY=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "1db42b7fe3878f3f5f7a4f2dc210772fd080e205",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixpkgs-20.03-darwin",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs-2105": {
-      "locked": {
-        "lastModified": 1659914493,
-        "narHash": "sha256-lkA5X3VNMKirvA+SUzvEhfA7XquWLci+CGi505YFAIs=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "022caabb5f2265ad4006c1fa5b1ebe69fb0c3faf",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixpkgs-21.05-darwin",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs-2111": {
-      "locked": {
-        "lastModified": 1659446231,
-        "narHash": "sha256-hekabNdTdgR/iLsgce5TGWmfIDZ86qjPhxDg/8TlzhE=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "eabc38219184cc3e04a974fe31857d8e0eac098d",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixpkgs-21.11-darwin",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs-2205": {
-      "locked": {
-        "lastModified": 1685573264,
-        "narHash": "sha256-Zffu01pONhs/pqH07cjlF10NnMDLok8ix5Uk4rhOnZQ=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "380be19fbd2d9079f677978361792cb25e8a3635",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixpkgs-22.05-darwin",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs-2211": {
-      "locked": {
-        "lastModified": 1688392541,
-        "narHash": "sha256-lHrKvEkCPTUO+7tPfjIcb7Trk6k31rz18vkyqmkeJfY=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "ea4c80b39be4c09702b0cb3b42eab59e2ba4f24b",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixpkgs-22.11-darwin",
+        "owner": "nixos",
+        "ref": "release-25.05",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -686,11 +631,11 @@
     },
     "nixpkgs-2405": {
       "locked": {
-        "lastModified": 1720122915,
-        "narHash": "sha256-Nby8WWxj0elBu1xuRaUcRjPi/rU3xVbkAt2kj4QwX2U=",
+        "lastModified": 1735564410,
+        "narHash": "sha256-HB/FA0+1gpSs8+/boEavrGJH+Eq08/R2wWNph1sM1Dg=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "835cf2d3f37989c5db6585a28de967a667a75fb1",
+        "rev": "1e7a8f391f1a490460760065fa0630b5520f9cf8",
         "type": "github"
       },
       "original": {
@@ -700,50 +645,66 @@
         "type": "github"
       }
     },
-    "nixpkgs-regression": {
+    "nixpkgs-2411": {
       "locked": {
-        "lastModified": 1643052045,
-        "narHash": "sha256-uGJ0VXIhWKGXxkeNnq4TvV3CIOkUJ3PAoLZ3HMzNVMw=",
+        "lastModified": 1751290243,
+        "narHash": "sha256-kNf+obkpJZWar7HZymXZbW+Rlk3HTEIMlpc6FCNz0Ds=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "215d4d0fd80ca5163643b03a33fde804a29cc1e2",
+        "rev": "5ab036a8d97cb9476fbe81b09076e6e91d15e1b6",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
+        "ref": "nixpkgs-24.11-darwin",
         "repo": "nixpkgs",
-        "rev": "215d4d0fd80ca5163643b03a33fde804a29cc1e2",
+        "type": "github"
+      }
+    },
+    "nixpkgs-2505": {
+      "locked": {
+        "lastModified": 1764560356,
+        "narHash": "sha256-M5aFEFPppI4UhdOxwdmceJ9bDJC4T6C6CzCK1E2FZyo=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "6c8f0cca84510cc79e09ea99a299c9bc17d03cb6",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-25.05-darwin",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-2511": {
+      "locked": {
+        "lastModified": 1764572236,
+        "narHash": "sha256-hLp6T/vKdrBQolpbN3EhJOKTXZYxJZPzpnoZz+fEGlE=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b0924ea1889b366de6bb0018a9db70b2c43a15f8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-25.11-darwin",
+        "repo": "nixpkgs",
         "type": "github"
       }
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1720181791,
-        "narHash": "sha256-i4vJL12/AdyuQuviMMd1Hk2tsGt02hDNhA0Zj1m16N8=",
+        "lastModified": 1764587062,
+        "narHash": "sha256-hdFa0TAVQAQLDF31cEW3enWmBP+b592OvHs6WVe3D8k=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "4284c2b73c8bce4b46a6adf23e16d9e2ec8da4bb",
+        "rev": "c1cb7d097cb250f6e1904aacd5f2ba5ffd8a49ce",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "ref": "nixpkgs-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_2": {
-      "locked": {
-        "lastModified": 1684171562,
-        "narHash": "sha256-BMUWjVWAUdyMWKk0ATMC9H0Bv4qAV/TXwwPUvTiC5IQ=",
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "rev": "55af203d468a6f5032a519cba4f41acf5a74b638",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nixos",
-        "ref": "release-22.11",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -815,11 +776,11 @@
     "stackage": {
       "flake": false,
       "locked": {
-        "lastModified": 1727827866,
-        "narHash": "sha256-bSEM80HtE9ov9PyJKNnC3D7e66kfQdhQ1U+F1TbH9Nc=",
+        "lastModified": 1768436049,
+        "narHash": "sha256-7BywgwT9Dh9zmvKNlCpa2PlezBLLjHxY544n546VlMA=",
         "owner": "input-output-hk",
         "repo": "stackage.nix",
-        "rev": "150ed1cfc88e1c543b455594b42155755fffc249",
+        "rev": "9c4b5fcf59684eb3c4b59602793a3fa1422254d8",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -40,14 +40,12 @@
         };
         inherit (nixpkgs) lib;
 
-        # See flake `variants` below for alternative compilers
-        defaultCompiler = "ghc966";
         # We use cabalProject' to ensure we don't build the plan for
         # all systems.
         cabalProject = nixpkgs.haskell-nix.cabalProject' ({config, ...}: {
           src = ./.;
           name = "cardano-faucet";
-          compiler-nix-name = lib.mkDefault defaultCompiler;
+          compiler-nix-name = lib.mkDefault "ghc96";
 
           # We also want cross compilation to windows on linux (and only with default compiler).
           # TODO: re-enable cross once mingw32 build isn't missing attribute `alex` at the latest haskellNix pin
@@ -66,20 +64,18 @@
           # tools we want in our shell, from hackage
           shell.tools =
             {
-              cabal = "3.10.3.0";
-              ghcid = "0.8.9";
-            }
-            // lib.optionalAttrs (config.compiler-nix-name == defaultCompiler) {
-              # tools that work only with default compiler
+              cabal = "3.12.1.0";
               fourmolu = "0.14.0.0";
-              haskell-language-server.src = nixpkgs.haskell-nix.sources."hls-2.9";
+              ghcid = "0.8.9";
+              haskell-language-server.src = nixpkgs.haskell-nix.sources."hls-2.12";
               hlint = "3.8";
+              # TODO[sgillespie]: Why do we need fourmolu and stylish-haskell?
               stylish-haskell = "0.14.6.0";
             };
           # and from nixpkgs or other inputs
           shell.nativeBuildInputs = with nixpkgs; [ gh jq yq-go ];
           # disable Hoogle until someone request it
-          shell.withHoogle = false;
+          shell.withHoogle = true;
           # Skip cross compilers for the shell
           shell.crossPlatforms = _: [];
 
@@ -135,14 +131,7 @@
           ];
         });
         # ... and construct a flake from the cabal project
-        flake = cabalProject.flake (
-          lib.optionalAttrs (system == "x86_64-linux") {
-            # on linux, build/test other supported compilers
-            variants = lib.genAttrs ["ghc8107"] (compiler-nix-name: {
-              inherit compiler-nix-name;
-            });
-          }
-        );
+        flake = cabalProject.flake {};
       in
         lib.recursiveUpdate flake rec {
           project = cabalProject;


### PR DESCRIPTION
Update flake inputs and haskell dependencies. Specifically, upgrade cardano-api to 10.19 (cardano-node 10.6.x), and fix the resulting compiler errors.