### PR TITLE
Faucet 11.0

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -14,7 +14,7 @@ repository cardano-haskell-packages
 -- you need to run if you change them
 index-state:
   , hackage.haskell.org 2026-03-26T20:21:33Z
-  , cardano-haskell-packages 2026-04-14T21:25:56Z
+  , cardano-haskell-packages 2026-05-02T16:21:41Z
 
 packages:
   cardano-faucet

--- a/cardano-faucet/cardano-faucet.cabal
+++ b/cardano-faucet/cardano-faucet.cabal
@@ -1,7 +1,7 @@
 cabal-version: 3.0
 
 name:                   cardano-faucet
-version:                10.7
+version:                11.0
 description:            The Cardano command-line interface.
 author:                 IOHK
 maintainer:             operations@iohk.io
@@ -63,7 +63,7 @@ library
                       , MissingH
                       , bytestring
                       , cardano-addresses  >= 4
-                      , cardano-api       ^>= 10.26
+                      , cardano-api       ^>= 11.0
                       , cardano-cli
                       , cardano-prelude
                       , containers


### PR DESCRIPTION
- Bump cardano-api from `^>= 10.26` to `^>= 11.0`
- Bump CHaP index-state to `2026-05-02T16:21:41Z`
- Bump faucet version to `11.0`
- No source changes required; API surface identical to `10.26`